### PR TITLE
Correct number of transform levels

### DIFF
--- a/src/wavelet/TimeScaleMODWT.jl
+++ b/src/wavelet/TimeScaleMODWT.jl
@@ -44,9 +44,7 @@ end
 function get_modwt(x::AbstractVector{T}, wl::Wavelets.WT.OrthoWaveletClass = Wavelets.WT.Daubechies{12}()) where T<:Real
     orthofilter = wavelet(wl)
     nscales = Wavelets.WT.maxmodwttransformlevels(x)
-    # The detail coefficients are the first 1:nscales columns; the last column is the 
-    # scaling coefficients, which we don't need.
-    W = modwt(x, orthofilter, nscales)[:, 1:end-1]
+    W = modwt(x, orthofilter, nscales)
 end
 
 function energy_at_scale(W::AbstractArray{T, 2}, j::Int) where T<:Real

--- a/src/wavelet/TimeScaleMODWT.jl
+++ b/src/wavelet/TimeScaleMODWT.jl
@@ -43,8 +43,10 @@ end
 
 function get_modwt(x::AbstractVector{T}, wl::Wavelets.WT.OrthoWaveletClass = Wavelets.WT.Daubechies{12}()) where T<:Real
     orthofilter = wavelet(wl)
-    nscales = Wavelets.maxmodwttransformlevels(x)
-    W = modwt(x, orthofilter, nscales)
+    nscales = Wavelets.WT.maxmodwttransformlevels(x)
+    # The detail coefficients are the first 1:nscales columns; the last column is the 
+    # scaling coefficients, which we don't need.
+    W = modwt(x, orthofilter, nscales)[:, 1:end-1]
 end
 
 function energy_at_scale(W::AbstractArray{T, 2}, j::Int) where T<:Real

--- a/src/wavelet/TimeScaleMODWT.jl
+++ b/src/wavelet/TimeScaleMODWT.jl
@@ -43,7 +43,7 @@ end
 
 function get_modwt(x::AbstractVector{T}, wl::Wavelets.WT.OrthoWaveletClass = Wavelets.WT.Daubechies{12}()) where T<:Real
     orthofilter = wavelet(wl)
-    nscales = maxdyadiclevel(x)
+    nscales = Wavelets.maxmodwttransformlevels(x)
     W = modwt(x, orthofilter, nscales)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -288,9 +288,10 @@ end
         t = LinRange(0, 2*a*π, N)
         x = sin.(t .+  cos.(t/0.1)) .- 0.1;
 
-        @testset "TimeScaleMODWT" begin
+        @testset "Wavelet internals" begin
             wl = WT.Daubechies{4}()
-            est = TimeScaleMODWT(wl)
+            W = Entropies.get_modwt(x)
+            @test size(W, 2) == floor(Int, log2(length(x)))
 
             @test Entropies.get_modwt(x) isa AbstractArray{<:Real, 2}
             @test Entropies.get_modwt(x, wl) isa AbstractArray{<:Real, 2}
@@ -307,6 +308,12 @@ end
 
             @test Entropies.relative_wavelet_energy(W, 1) isa Real
             @test Entropies.relative_wavelet_energies(W, 1:2) isa AbstractVector{<:Real}
+
+        end
+
+        @testset "TimeScaleMODWT" begin
+            wl = WT.Daubechies{4}()
+            est = TimeScaleMODWT(wl)
 
             @test Entropies.time_scale_density(x, wl) isa AbstractVector{<:Real}
             @test genentropy(x, TimeScaleMODWT(), q = 1, base = 2) isa Real

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -289,10 +289,12 @@ end
         x = sin.(t .+  cos.(t/0.1)) .- 0.1;
 
         @testset "Wavelet internals" begin
-            wl = WT.Daubechies{4}()
-            W = Entropies.get_modwt(x)
+            wl = WT.Haar()
+            W = Entropies.get_modwt(x, wl)
             @test size(W, 2) == floor(Int, log2(length(x)))
-
+            # Test that we can resonstruct original signal from decomposition.
+            # Note: this only works for the Haar wavelet.
+            @test all(abs.(([sum(W[t, :]) for t = 1:N] .- x) .< 1e-8))
             @test Entropies.get_modwt(x) isa AbstractArray{<:Real, 2}
             @test Entropies.get_modwt(x, wl) isa AbstractArray{<:Real, 2}
 


### PR DESCRIPTION
Using `maxdyadiclevel` instead `maxmodwttransformlevels` caused one transform level to be missing. As a result, the wavelet entropy was computed on a probability distribution (relative energy distribution) with one less element than desired. The frequency range corresponding to the lowest/slowest frequencies was missing.