### PR TITLE
Tsallis entropy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
+
 Changelog is kept with respect to version 0.11 of Entropies.jl.
+
+## 1.3 
+* Introduce Tsallis entropy.
+
+## 1.2
+* Added dispersion entropy.
 
 ## 1.1
 * Introduce convenience function `permentropy`.

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Entropies"
 uuid = "ed8fcbec-b94c-44b6-89df-898894ad9591"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/Entropies.jl.git"
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,6 +13,8 @@ The main **API** of this package is contained in two functions:
 * [`probabilities`](@ref) which computes probability distributions of given datasets
 * [`genentropy`](@ref) which uses the output of [`probabilities`](@ref), or a set of
     pre-computed [`Probabilities`](@ref), to calculate entropies.
+* [`tsallisentropy`](@ref) which uses the output of [`probabilities`](@ref), or a set of
+    pre-computed [`Probabilities`](@ref), to calculate Tsallis entropies.
 
 These functions dispatch on subtypes of [`ProbabilitiesEstimator`](@ref), which are:
 
@@ -34,6 +36,7 @@ ProbabilitiesEstimator
 
 ```@docs
 Entropies.genentropy
+Entropies.tsallisentropy
 ```
 
 ## Fast histograms

--- a/src/Entropies.jl
+++ b/src/Entropies.jl
@@ -8,4 +8,6 @@ module Entropies
     include("wavelet/wavelet.jl")
     include("nearest_neighbors/nearest_neighbors.jl")
     include("dispersion/dispersion_entropy.jl")
+
+    include("tsallis/tsallis.jl")
 end

--- a/src/tsallis/tsallis.jl
+++ b/src/tsallis/tsallis.jl
@@ -1,0 +1,26 @@
+export tsallisentropy
+
+"""
+    tsallisentropy(x::Probabilities; k = 1, q = 0)
+
+Compute the Tsallis entropy of `x` (Tsallis, 1998)[^Tsallis1988].
+
+```math
+S_q(\\bf p) = \\dfrac{k}{q - 1}\\left(1 - \\sum_{p_i \\in \\bf p} \\right)
+```
+
+[^Tsallis1988]: Tsallis, C. (1988). Possible generalization of Boltzmann-Gibbs statistics. Journal of statistical physics, 52(1), 479-487.
+"""
+function tsallisentropy(prob::Probabilities; k = 1, q = 0)
+    haszero = any(iszero, prob)
+    p = if haszero
+        i0 = findall(iszero, prob.p)
+        # As for genentropy, we copy because if someone initialized Probabilities with 0s,
+        # they'd probably want to index the zeros as well.
+        deleteat!(copy(prob.p), i0)
+    else
+        prob.p
+    end
+
+    return k/(q-1)*(1 - sum(prob .^ q))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -376,4 +376,9 @@ end
         @test typeof(de) <: Real
         @test de >= 0.0
     end
+
+    @testset "Tsallis" begin
+        p = Probabilities(repeat([1/5], 5))
+        @assert round(tsallisentropy(p, q = -1/2, k = 1), digits = 2) ≈ 6.79
+    end
 end


### PR DESCRIPTION
Tsallis (non-logarithm) entropy.

## References

Tsallis, C. (1988). Possible generalization of Boltzmann-Gibbs statistics. Journal of statistical physics, 52(1), 479-487.

