### PR TITLE
Dispersion entropy: follow main API,  use `entropy_dispersion`, and use more tests

### DIFF
--- a/src/dispersion/dispersion_entropy.jl
+++ b/src/dispersion/dispersion_entropy.jl
@@ -1,9 +1,35 @@
 using DelayEmbeddings
 using StatsBase
 
+export Dispersion
+export entropy_dispersion
 include("GaussianSymbolization.jl")
 
-export dispersion_entropy
+"""
+    Dispersion(; s = GaussianSymbolization(5), m = 2, τ = 1, check_unique = true)
+
+A probability estimator using the dispersion entropy technique from
+Rostaghi & Azami (2016)[^Rostaghi2016].
+
+Although the dispersion entropy is not intended as a probability estimator per se,
+it requires a step where probabilities are explicitly computed. Hence, we provide
+`Dispersion` as a probability estimator.
+
+See [`entropy_dispersion`](@ref) for the meaning of parameters.
+
+!!! info
+    This estimator is only available for probability estimation.
+
+[^Rostaghi2016]: Rostaghi, M., & Azami, H. (2016). Dispersion entropy: A measure for time-series analysis. IEEE Signal Processing Letters, 23(5), 610-614.
+"""
+Base.@kwdef struct Dispersion <: ProbabilitiesEstimator
+    s = GaussianSymbolization(n_categories = 5)
+    m = 2
+    τ = 1
+    check_unique = false
+end
+
+export entropy_dispersion
 
 """
     embed_symbols(s::AbstractVector{T}, m, τ) {where T} → Dataset{m, T}
@@ -20,19 +46,38 @@ function embed_symbols(symbols::AbstractVector, m, τ)
     return embed(symbols, m, τ)
 end
 
-
 function dispersion_histogram(x::AbstractDataset, N, m, τ)
     return _non0hist(x.data, (N - (m - 1)*τ))
 end
 
+function probabilities(x::AbstractVector, est::Dispersion)
+    if est.check_unique
+        if length(unique(x)) == 1
+            symbols = repeat([1], length(x))
+        else
+            symbols = symbolize(x, est.s)
+        end
+    else
+        symbols = symbolize(x, est.s)
+    end
+    N = length(x)
+
+    # We must use genembed, not embed, to make sure the zero lag is included
+    m, τ = est.m, est.τ
+    τs = tuple((x for x in 0:-τ:-(m-1)*τ)...)
+    dispersion_patterns = genembed(symbols, τs, ones(m))
+
+    𝐩 = Probabilities(dispersion_histogram(dispersion_patterns, N, est.m, est.τ))
+end
 
 """
-    dispersion_entropy(x, s = GaussianSymbolization(n_categories = 5);
+    entropy_dispersion(x, s = GaussianSymbolization(n_categories = 5);
         m = 3, τ = 1, q = 1, base = MathConstants.e)
 
-Compute the (order-`q` generalized) dispersion entropy to the given `base` of the
-univariate time series `x`. Relative frequencies of dispersion patterns are computed using
-the symbolization scheme `s` with embedding dimension `m` and embedding delay `τ`.
+Compute the dispersion entropy (Rostaghi & Azami, 2016)[^Rostaghi2016] to order `q`
+and the given `base` of the univariate time series `x`. Relative frequencies of dispersion
+patterns are computed using the symbolization scheme `s` with embedding dimension `m` and
+embedding delay `τ`.
 
 Recommended parameter values[^Li2018] are `m ∈ [2, 3]`, `τ = 1`, and
 `n_categories ∈ [3, 4, …, 8]` for the Gaussian mapping (defaults to 5).
@@ -46,18 +91,31 @@ generalized dispersion entropy of order `q` (default is `q = 1`, which is the Sh
 
 ## Data requirements
 
+The input must have more than one unique element for the Gaussian mapping to be
+well-defined. If `check_unique == true` (default), then it is checked that the input has
+more than one unique value. If `check_unique == false` and the input only has one
+unique element, then a `InexactError` is thrown.
+
 Li et al. (2018) recommends that `x` has at least 1000 data points.
 
+See also: [`Dispersion`](@ref).
+
+[^Rostaghi2016]: Rostaghi, M., & Azami, H. (2016). Dispersion entropy: A measure for time-series analysis. IEEE Signal Processing Letters, 23(5), 610-614.
 [^Li2018]: Li, G., Guan, Q., & Yang, H. (2018). Noise reduction method of underwater acoustic signals based on CEEMDAN, effort-to-compress complexity, refined composite multiscale dispersion entropy and wavelet threshold denoising. Entropy, 21(1), 11.
 [^Azami2018]: Azami, H., & Escudero, J. (2018). Coarse-graining approaches in univariate multiscale sample and dispersion entropy. Entropy, 20(2), 138.
 """
-function dispersion_entropy(x::AbstractVector,
-        s::GaussianSymbolization = GaussianSymbolization(n_categories = 5);
-        m = 2, τ = 1, q = 1, base = MathConstants.e)
-    symbols = symbolize(x, s)
-    dispersion_patterns = embed(symbols, m, τ)
-    N = length(x)
+function entropy_dispersion(x::AbstractVector;
+        s::GaussianSymbolization = GaussianSymbolization(n_categories = 5),
+        m = 2, τ = 1, q = 1, base = MathConstants.e, normalize = true,
+        check_unique = true)
+    est = Dispersion(m = m, τ = τ, s = s, check_unique = check_unique)
+    𝐩 = probabilities(x, est)
 
-    hist = dispersion_histogram(dispersion_patterns, N, m, τ)
-    genentropy(hist, q = q, base = base)
+    dh = genentropy(𝐩, q = q, base = base)
+
+    if normalize
+        return dh / log(base, s.n_categories^m)
+    else
+        return dh
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -355,6 +355,34 @@ end
     end
 
     @testset "Dispersion entropy" begin
+
+        est = Dispersion(m = 2, τ = 1, s = GaussianSymbolization(3), check_unique = true)
+
+        # Verify that symbolization works (example from Rostaghi & Azami, 2016)
+        x = [9,8,1,12,5,-3,1.5,8.01,2.99,4,-1,10]
+        symbols = symbolize(x, est.s)
+        @test symbols == [3, 3, 1, 3, 2, 1, 1, 3, 2, 2, 1, 3]
+
+
+        # Probabilities from their example
+        p_ex = [1/11, 3/11, 2/11, 1/11, 1/11, 2/11, 1/11] |> sort
+        @test p_ex == probabilities(x, est) |> sort
+
+        # There is probably a typo in their paper. They state that the non-normalized
+        # dispersion entropy is 1.8642. However, with identical probabilies, we obtain
+        # 1.8462.
+        res = entropy_dispersion(x, m = 2, τ = 1, base = MathConstants.e,
+            s = GaussianSymbolization(3), normalize = false)
+        @test round(res, digits = 4) == 1.8462
+
+        # Again, probabilities are identical up to this point, but the values we get differ
+        # slightly from the paper. They get normalized DE of 0.85, but we get 0.84. 0.85 is
+        # the normalized DE you'd get by manually normalizing the (erroneous) value from
+        # their previous step.
+        res_norm = entropy_dispersion(x, m = 2, τ = 1, base = MathConstants.e,
+            s = GaussianSymbolization(3), normalize = true)
+        @test round(res_norm, digits = 2) == 0.84
+
         # Li et al. (2018) recommends using at least 1000 data points when estimating
         # dispersion entropy.
         x = rand(1000)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -400,7 +400,7 @@ end
         hist = Entropies.dispersion_histogram(dispersion_patterns, length(x), m, τ)
         @test sum(hist) ≈ 1.0
 
-        de = dispersion_entropy(x, s, m = 4, τ = 1)
+        de = entropy_dispersion(x, s = s, m = 4, τ = 1)
         @test typeof(de) <: Real
         @test de >= 0.0
     end


### PR DESCRIPTION
# What is this PR

This PR introduces some api changes to the dispersion entropy, which fixes #82.

## Changes

- `dispersion_entropy` is now `entropy_dispersion`, as we agreed on in #81.
- Added primary reference.
- Added test cases from primary reference.

## Reviewing/merging

This PR should not be merged until the main API has changed, but can be reviewed. 

In #82, I stated that this fix should be pushed asap, but we may just as well wait until #80 and #81 are done, because the dispersion entropy is not yet documented anywhere, so it's not part of the official API.

I'm keeping the PR as a draft to remind myself to revisit this once #80 and #81 are done.