### PR TITLE
Clarify what happens to embedding parameters when input is a dataset

### DIFF
--- a/src/probabilities_estimators/permutation_ordinal/SymbolicPermutation.jl
+++ b/src/probabilities_estimators/permutation_ordinal/SymbolicPermutation.jl
@@ -15,7 +15,8 @@ If applied to a univariate time series, then the time series is first embedded u
 embedding delay `τ` and dimension `m`, and then converted to a symbol time series using
 [`symbolize`](@ref) with [`OrdinalPattern`](@ref), from which probabilities are
 estimated. If applied to a `Dataset`, then the data is assumed to be
-pre-symbolized, and probabilities are computed directly from the state vectors.
+pre-symbolized, `τ` and `m` are ignored, and probabilities are computed directly from
+the state vectors.
 
 !!! note "Handling equal values in ordinal patterns"
     In Bandt & Pompe (2002), equal values are ordered after their order of appearance, but


### PR DESCRIPTION
Fixes #108 