### PR TITLE
Curado entropy

### DIFF
--- a/docs/src/entropies.md
+++ b/docs/src/entropies.md
@@ -23,6 +23,12 @@ Tsallis
 Shannon
 ```
 
+## Curado entropy
+
+```@docs
+Curado
+```
+
 ## Normalized entropies
 
 ```@docs

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -144,6 +144,32 @@ for a in (ax, ay); hidexdecorations!(a; grid=false); end
 fig
 ```
 
+## Properties of different entropies
+
+### Curado entropy
+
+Here, we reproduce Figure 2 from Curado & Nobre (2004)[^Curado2004], showing
+how the [Curado](@ref) entropy changes as function of the parameter `a` for a range of two-element probability distributions given by
+`Probabilities([p, 1 - p] for p in 1:0.0:0.01:1.0)`.
+
+```@example stretched_exponential_example
+using Entropies, CairoMakie
+bs = [1.0, 1.5, 2.0, 3.0, 4.0, 10.0]
+ps = [Probabilities([p, 1 - p]) for p = 0.0:0.01:1.0]
+hs = [[entropy(Curado(; b = b), p) for p in ps] for b in bs]
+fig = Figure()
+ax = Axis(fig[1,1]; xlabel = "p", ylabel = "H(p)")
+pp = [p[1] for p in ps]
+for (i, b) in enumerate(bs)
+    lines!(ax, pp, hs[i], label = "b=$b", color = Cycled(i))
+end
+axislegend(ax)
+fig
+```
+
+[^Curado2004]: Curado, E. M., & Nobre, F. D. (2004). On the stability of analytic
+    entropic forms. Physica A: Statistical Mechanics and its Applications, 335(1-2), 94-106.
+
 ## [Dispersion and reverse dispersion entropy](@id dispersion_examples)
 
 Here we reproduce parts of figure 3 in Li et al. (2019), computing reverse and regular dispersion entropy for a time series consisting of normally distributed noise with a single spike in the middle of the signal. We compute the entropies over a range subsets of the data, using a sliding window consisting of 70 data points, stepping the window 10 time steps at a time.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -165,6 +165,7 @@ pp = [p[1] for p in ps]
 for (i, b) in enumerate(bs)
     lines!(ax, pp, hs[i], label = "b=$b", color = Cycled(i))
 end
+axislegend(ax)
 fig
 ```
 

--- a/src/entropies/curado.jl
+++ b/src/entropies/curado.jl
@@ -1,0 +1,36 @@
+export Curado
+import Base.maximum
+"""
+    Curado <: Entropy
+    Curado(; b = 1.0)
+
+The Curado entropy (Curado & Nobre, 2004)[^Curado2004], used with [`entropy`](@ref) to
+compute
+
+```math
+H_C(p) = \\left( \\sum_{i=1}^N e^{-b p_i} \\right) + e^{-b} - 1,
+```
+
+with `b ∈ ℛ, b > 0`, where the terms outside the sum ensures that ``H_C(0) = H_C(1) = 0``.
+
+[^Curado2004]: Curado, E. M., & Nobre, F. D. (2004). On the stability of analytic
+    entropic forms. Physica A: Statistical Mechanics and its Applications, 335(1-2), 94-106.
+"""
+struct Curado{B} <: Entropy
+    b::B
+    function Curado(; b::B = 1.0) where B <: Real
+        b > 0 || throw(ArgumentError("Need b > 0. Got b=$(b)."))
+        return new{B}(b)
+    end
+end
+
+function entropy(e::Curado, probs::Probabilities)
+    b = e.b
+    return sum(1 - exp(-b*pᵢ)  for pᵢ in probs) + exp(-b) - 1
+end
+
+function maximum(e::Curado, L::Int)
+    b = e.b
+    # Maximized for the uniform distribution, which for distribution of length L is
+    return L * (1 - exp(-b/L)) + exp(-b) - 1
+end

--- a/src/entropies/curado.jl
+++ b/src/entropies/curado.jl
@@ -16,9 +16,10 @@ with `b ∈ ℛ, b > 0`, where the terms outside the sum ensures that ``H_C(0) =
 [^Curado2004]: Curado, E. M., & Nobre, F. D. (2004). On the stability of analytic
     entropic forms. Physica A: Statistical Mechanics and its Applications, 335(1-2), 94-106.
 """
-struct Curado{B} <: Entropy
-    b::B
-    function Curado(; b::B = 1.0) where B <: Real
+Base.@kwdef struct Curado{B} <: Entropy
+    b::B = 1.0
+
+    function Curado(b::B) where B <: Real
         b > 0 || throw(ArgumentError("Need b > 0. Got b=$(b)."))
         return new{B}(b)
     end

--- a/src/entropies/entropies.jl
+++ b/src/entropies/entropies.jl
@@ -1,5 +1,6 @@
 include("renyi.jl")
 include("tsallis.jl")
+include("curado.jl")
 include("convenience_definitions.jl")
 include("direct_entropies/nearest_neighbors/nearest_neighbors.jl")
 # TODO: What else is included here from direct entropies?

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -31,6 +31,7 @@ entropies". Currently implemented types are:
 - [`Renyi`](@ref).
 - [`Tsallis`](@ref).
 - [`Shannon`](@ref), which is a subcase of the above two in the limit `q → 1`.
+- [`Curado`](@ref).
 
 The entropy (first argument) is optional: if not given, `Shannon()` is used instead.
 

--- a/test/entropies/curado.jl
+++ b/test/entropies/curado.jl
@@ -1,0 +1,16 @@
+N = 10
+bs = [0.5, 1.0, 2.0, 5.0, 10.0]
+
+# Analytical tests from Curado (2004).
+# -----------------------------------
+
+# Curado entropy is maximized for uniform distribution.
+max_hs = [maximum(Curado(b = b), N) for b in bs]
+pu = Probabilities(repeat([1/N], N))
+hs = [entropy(Curado(b = b), pu) for b in bs]
+@test all([h ≈ maxh for (h, maxh) in zip(hs, max_hs)])
+
+# Curado entropy is minimized and equal 0 for one-element distributions
+p1 = Probabilities([1.0])
+hs_p1 = [entropy(Curado(b = b), p1) for b in bs]
+@test all([h ≈ 0.0 for h in hs_p1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ testfile(file, testname=defaultname(file)) = @testset "$testname" begin; include
     testfile("entropies/renyi.jl")
     testfile("entropies/shannon.jl")
     testfile("entropies/tsallis.jl")
+    testfile("entropies/curado.jl")
     testfile("entropies/nearest_neighbors_direct.jl")
 
     # Various


### PR DESCRIPTION
## What is this PR?

This PR implements the Curado entropy (Curado & Nobre, 2004).

Contains:
- The `Curado` entropy type, which implements `entropy(e, probs::Probabilities)`, `entropy(e, x, est::ProbabilitiesEstimator` (through the interface), and `maximum`.
- A documentation entry.
- An example in the docs showcasing how the entropy behaves as a function of its parameter `b`, reproducing Figure 2 in Curado & Nobre (2004).
- Analytical tests from the original paper.
- A link in the `entropy` docstring to the method.


## References

Curado, E. M., & Nobre, F. D. (2004). On the stability of analytic entropic forms. Physica A: Statistical Mechanics and its Applications, 335(1-2), 94-106.