### PR TITLE
Added convenience methods for passing stencils to functions

### DIFF
--- a/src/probabilities_estimators/permutation_ordinal/spatial_permutation.jl
+++ b/src/probabilities_estimators/permutation_ordinal/spatial_permutation.jl
@@ -11,6 +11,9 @@ The input data `x` are high-dimensional arrays, for example 2D arrays [^Ribeiro2
 
 A _stencil_ defines what local area (which points) around each pixel to
 consider, and compute ordinal patterns from.
+The number of included points in a stencil (`m`) determines the length of the vectors
+to be symbolized, i.e. there are `m!` possible ordinal patterns around each pixel.
+
 Stencils are passed in one of the following three ways:
 
 1. As vectors of `CartesianIndex` which encode the pixels to include in the
@@ -27,8 +30,6 @@ Stencils are passed in one of the following three ways:
     which is almost always the case.
     Here the stencil creates a 2x2 square extending to the bottom and right of the pixel
     (directions here correspond to the way Julia prints matrices by default).
-    The number of included points in a stencil (`m`) determines the length of the vectors
-    to be symbolized, i.e. there are `m!` possible ordinal patterns around each pixel.
     When passing a stencil as a vector of `CartesianIndex`, `m = length(stencil)`.
 
 2. As a `D`-dimensional array (where `D` matches the dimensionality of the input data)
@@ -42,6 +43,7 @@ Stencils are passed in one of the following three ways:
     stencil = [1 1; 1 1]
     est = SpatialSymbolicPermutation(stencil, x)
     ```
+    When passing a stencil as a `D`-dimensional array, `m = sum(stencil)`
 
 3. As a `Tuple` containing two `Tuple`s, both of length `D`, for `D`-dimensional data.
     The first tuple specifies the `extent` of the stencil, where `extent[i]` 
@@ -55,6 +57,7 @@ Stencils are passed in one of the following three ways:
     x = data[1] # first "time slice" of a spatial system evolution
     est = SpatialSymbolicPermutation(((2, 2), (1, 1)), x)
     ```
+    When passing a stencil using `extent` and `lag`, `m = prod(extent)!`.
 
 After having defined `est`, one calculates the spatial permutation entropy
 by calling [`entropy`](@ref) with `est`, and with the array data.

--- a/src/probabilities_estimators/permutation_ordinal/spatial_permutation.jl
+++ b/src/probabilities_estimators/permutation_ordinal/spatial_permutation.jl
@@ -27,9 +27,9 @@ Stencils are passed in one of the following three ways:
     which is almost always the case.
     Here the stencil creates a 2x2 square extending to the bottom and right of the pixel
     (directions here correspond to the way Julia prints matrices by default).
-    The length of the stencil decides the order of the permutation entropy, and the ordering
-    within the stencil dictates the order that pixels are compared with.
-    The pixel without any offset is always first in the order.
+    The number of included points in a stencil (`m`) determines the length of the vectors
+    to be symbolized, i.e. there are `m!` possible ordinal patterns around each pixel.
+    When passing a stencil as a vector of `CartesianIndex`, `m = length(stencil)`.
 
 2. As a `D`-dimensional array (where `D` matches the dimensionality of the input data)
     containing `0`s and `1`s, where if `stencil[index] == 1`, the corresponding pixel is

--- a/src/probabilities_estimators/permutation_ordinal/spatial_permutation.jl
+++ b/src/probabilities_estimators/permutation_ordinal/spatial_permutation.jl
@@ -39,10 +39,10 @@ The length of the stencil decides the order of the permutation entropy, and the 
 within the stencil dictates the order that pixels are compared with.
 The pixel without any offset is always first in the order.
 
-For rectangular/ cuboid stencils, one can also pass two `NTuple`s `extent` and `lag`,
-from which an appropriate stencil will be created. 
-`extent` defines how many points should be considered in each direction, and `lag`
-defines the offset between them.
+For rectangular/ cuboid stencils, one can also pass two `NTuple{D, T}`s `extent` and `lag`
+for D-dimensional data, from which an appropriate stencil is be created. 
+`extent[i]` defines how many points are be considered along the `i`th axis, and `lag[i]`
+defines the spacing between the points along this axis.
 The above example can also be achieved using
 
 ```julia
@@ -101,26 +101,14 @@ function SpatialSymbolicPermutation(
 end
 
 function SpatialSymbolicPermutation(
-    extent::NTuple{2, Int}, lag::NTuple{2, Int}, x::AbstractArray, p::Bool = true
-    )
-    # generate 2d stencil
-    stencil = CartesianIndex.([(i*lag[1], j*lag[2])
-                               for i in 0:extent[1]-1
-                               for j in 0:extent[2]-1])
-    # remove (0,0) index because that's the convention
-    popfirst!(stencil)
-    SpatialSymbolicPermutation(stencil, x, p)
-end
-
-function SpatialSymbolicPermutation(
-    extent::NTuple{3, Int}, lag::NTuple{3, Int}, x::AbstractArray, p::Bool = true
-    )
+    extent::NTuple{D, Int}, lag::NTuple{D, Int}, x::AbstractArray, p::Bool = true
+    ) where D
     # generate 3d stencil
-    stencil = CartesianIndex.([(i*lag[1], j*lag[2], k*lag[3])
-                               for i in 0:extent[1]-1
-                               for j in 0:extent[2]-1
-                               for k in 0:extent[3]-1])
-    # remove (0,0,0) index because that's the convention
+    # start by generating a list of iterators for each dimension
+    iters = [0:lag[i]:extent[i]-1 for i in 1:D]
+    # then generate the stencil. We use an iterator product that we basically only reshape after that
+    stencil = CartesianIndex.(vcat(collect(Iterators.product(iters...))...))
+    # remove (0,0,...) index because that's the convention
     popfirst!(stencil)
     SpatialSymbolicPermutation(stencil, x, p)
 end

--- a/src/probabilities_estimators/permutation_ordinal/spatial_permutation.jl
+++ b/src/probabilities_estimators/permutation_ordinal/spatial_permutation.jl
@@ -2,6 +2,7 @@ export SpatialSymbolicPermutation
 
 """
     SpatialSymbolicPermutation(stencil, x, periodic = true)
+    SpatialSymbolicPermutation(extent, lag, x, periodic = true)
 
 A symbolic, permutation-based probabilities/entropy estimator for spatiotemporal systems.
 

--- a/src/probabilities_estimators/permutation_ordinal/spatial_permutation.jl
+++ b/src/probabilities_estimators/permutation_ordinal/spatial_permutation.jl
@@ -9,11 +9,11 @@ The input data `x` are high-dimensional arrays, for example 2D arrays [^Ribeiro2
 [^Schlemmer2018]. This approach is also known as _spatiotemporal permutation entropy_.
 `x` is given because we need to know its size for optimization and bound checking.
 
-A _stencil_ defines what local area around each pixel to
-consider, and compute the ordinal pattern within the stencil.
+A _stencil_ defines what local area (which points) around each pixel to
+consider, and compute ordinal patterns from.
 Stencils are passed in one of the following three ways:
 
-1. as vectors of `CartesianIndex` which encode the pixels to include in the
+1. As vectors of `CartesianIndex` which encode the pixels to include in the
     stencil, with respect to the current pixel, or integer arrays of the same dimensionality
     as the data. For example
 
@@ -23,7 +23,7 @@ Stencils are passed in one of the following three ways:
     stencil = CartesianIndex.([(0,0), (0,1), (1,1), (1,0)])
     est = SpatialSymbolicPermutation(stencil, x)
     ```
-    Don't forget to include 0 offset if you want to include the point itself, 
+    Don't forget to include the zero offset index if you want to include the point itself, 
     which is almost always the case.
     Here the stencil creates a 2x2 square extending to the bottom and right of the pixel
     (directions here correspond to the way Julia prints matrices by default).
@@ -31,9 +31,10 @@ Stencils are passed in one of the following three ways:
     within the stencil dictates the order that pixels are compared with.
     The pixel without any offset is always first in the order.
 
-2. as a `D`-dimensional array (where `D` matches the dimensionality of the input data)
-    containing `0`s and `1`s, where every pixel with a one is included.
-    To generate the same estimator as in 1., for example
+2. As a `D`-dimensional array (where `D` matches the dimensionality of the input data)
+    containing `0`s and `1`s, where if `stencil[index] == 1`, the corresponding pixel is
+    included, and if `stencil[index] == 0`, it is not included.
+    To generate the same estimator as in 1., use
 
     ```julia
     data = [rand(50, 50) for _ in 1:50]
@@ -42,11 +43,11 @@ Stencils are passed in one of the following three ways:
     est = SpatialSymbolicPermutation(stencil, x)
     ```
 
-3. as a `Tuple` containing two `Tuple`s of length `D` for `D`-dimensional data.
+3. As a `Tuple` containing two `Tuple`s, both of length `D`, for `D`-dimensional data.
     The first tuple specifies the `extent` of the stencil, where `extent[i]` 
     dictates the number of pixels to be included along the `i`th axis and `lag[i]`
-    their respective separation.
-    This method can only generate cuboid stencils. To create the same estimator as
+    the separation of pixels along the same axis.
+    This method can only generate (hyper)rectangular stencils. To create the same estimator as
     in the previous examples, use here
 
     ```julia
@@ -107,7 +108,7 @@ function SpatialSymbolicPermutation(
     ) where {D, T}
     # get extent and lag from stencil
     extent, lag = stencil
-    # generate 3d stencil
+    # generate a D-dimensional stencil
     # start by generating a list of iterators for each dimension
     iters = [0:lag[i]:extent[i]-1 for i in 1:D]
     # then generate the stencil. We use an iterator product that we basically only reshape after that

--- a/test/estimators/permutation_spatial.jl
+++ b/test/estimators/permutation_spatial.jl
@@ -60,8 +60,8 @@ using Entropies, Test
     ps = probabilities(w, est)
     @test length(ps) > 1
 
-    # check that the 3d-cuboid version also works as expected
-    # this stencil is a cuboid
+    # check that the 3d-hyperrectangle version also works as expected
+    # this stencil is a hyperrectangle
     stencil = CartesianIndex.([(0,0,0), (0,1,0), (0,0,1),
                                (1,0,0), (0,1,1), (1,0,1),
                                (1,1,0), (1,1,1)])

--- a/test/estimators/permutation_spatial.jl
+++ b/test/estimators/permutation_spatial.jl
@@ -5,7 +5,7 @@ using Entropies, Test
     # Re-create the Ribeiro et al, 2012 using stencil
     # (you get 4 symbols in a 3x3 matrix. For this matrix, the upper left
     # and bottom right are the same symbol. So three probabilities in the end).
-    stencil = CartesianIndex.([(1,0), (0,1), (1,1)])
+    stencil = CartesianIndex.([(0,0), (1,0), (0,1), (1,1)])
     est = SpatialSymbolicPermutation(stencil, x, false)
 
     # Generic tests
@@ -19,13 +19,13 @@ using Entropies, Test
 
     # In fact, doesn't matter how we order the stencil,
     # the symbols will always be equal in top-left and bottom-right
-    stencil = CartesianIndex.([(1,0), (1,1), (0,1)])
+    stencil = CartesianIndex.([(0,0), (1,0), (1,1), (0,1)])
     est = SpatialSymbolicPermutation(stencil, x, false)
     @test entropy(Renyi(base = 2), x, est) == 1.5
 
     # But for sanity, let's ensure we get a different number
     # for a different stencil
-    stencil = CartesianIndex.([(1,0), (2,0)])
+    stencil = CartesianIndex.([(0,0), (1,0), (2,0)])
     est = SpatialSymbolicPermutation(stencil, x, false)
     ps = sort(probabilities(x, est))
     @test ps[1] == 1/3
@@ -33,7 +33,9 @@ using Entropies, Test
 
     # let's also check we get the same value as above
     # if we specify extent and lag instead of stencil
-    est = SpatialSymbolicPermutation((2,2), (1,1), x, false)
+    extent = (2, 2)
+    lag = (1, 1)
+    est = SpatialSymbolicPermutation((extent, lag), x, false)
     @test entropy(Renyi(base = 2), x, est) == 1.5
 
     # and let's also test the matrix-way of specifying the stencil
@@ -45,7 +47,7 @@ using Entropies, Test
 
 
     # Also test that it works for arbitrarily high-dimensional arrays
-    stencil = CartesianIndex.([(0,1,0), (0,0,1), (1,0,0)])
+    stencil = CartesianIndex.([(0,0,0), (0,1,0), (0,0,1), (1,0,0)])
     z = reshape(1:125, (5,5,5))
     est = SpatialSymbolicPermutation(stencil, z, false)
     # Analytically the total stencils are of length 4*4*4 = 64
@@ -60,12 +62,14 @@ using Entropies, Test
 
     # check that the 3d-cuboid version also works as expected
     # this stencil is a cuboid
-    stencil = CartesianIndex.([(0,1,0), (0,0,1), (1,0,0),
-                               (0,1,1), (1,0,1), (1,1,0),
-                               (1,1,1)])
+    stencil = CartesianIndex.([(0,0,0), (0,1,0), (0,0,1),
+                               (1,0,0), (0,1,1), (1,0,1),
+                               (1,1,0), (1,1,1)])
     est1 = SpatialSymbolicPermutation(stencil, w, false)
-    # which would correspond to this 
-    est2 = SpatialSymbolicPermutation((2,2,2), (1,1,1), w, false)
+    # which would correspond to this
+    extent = (2, 2, 2)
+    lag = (1, 1, 1)
+    est2 = SpatialSymbolicPermutation((extent, lag), w, false)
     @test entropy(Renyi(), w, est1) == entropy(Renyi(), w, est2)
 
     # and to this stencil written as a matrix

--- a/test/estimators/permutation_spatial.jl
+++ b/test/estimators/permutation_spatial.jl
@@ -31,7 +31,18 @@ using Entropies, Test
     @test ps[1] == 1/3
     @test ps[2] == 2/3
 
+    # let's also check we get the same value as above
+    # if we specify extent and lag instead of stencil
+    est = SpatialSymbolicPermutation((2,2), (1,1), x, false)
+    @test entropy(Renyi(base = 2), x, est) == 1.5
+
+    # and let's also test the matrix-way of specifying the stencil
+    stencil = [1 1; 1 1]
+    est = SpatialSymbolicPermutation(stencil, x, false)
+    @test entropy(Renyi(base = 2), x, est) == 1.5
+    
     # TODO: Symbolize tests once its part of the API.
+
 
     # Also test that it works for arbitrarily high-dimensional arrays
     stencil = CartesianIndex.([(0,1,0), (0,0,1), (1,0,0)])
@@ -46,4 +57,19 @@ using Entropies, Test
     w = shuffle!(Random.MersenneTwister(42), collect(z))
     ps = probabilities(w, est)
     @test length(ps) > 1
+
+    # check that the 3d-cuboid version also works as expected
+    # this stencil is a cuboid
+    stencil = CartesianIndex.([(0,1,0), (0,0,1), (1,0,0),
+                               (0,1,1), (1,0,1), (1,1,0),
+                               (1,1,1)])
+    est1 = SpatialSymbolicPermutation(stencil, w, false)
+    # which would correspond to this 
+    est2 = SpatialSymbolicPermutation((2,2,2), (1,1,1), w, false)
+    @test entropy(Renyi(), w, est1) == entropy(Renyi(), w, est2)
+
+    # and to this stencil written as a matrix
+    stencil = [1; 1;; 1; 1;;; 1; 1;; 1; 1]
+    est3 = SpatialSymbolicPermutation(stencil, w, false)
+    @test entropy(Renyi(), w, est1) == entropy(Renyi(), w, est3)
 end


### PR DESCRIPTION
Hi there!

I added a few convenience methods for passing stencils to `SpatialSymbolicPermutation`, namely:

- for 2D and 3D, pass rectangular/ cuboid stencils just via their `extent` (an extension of the word length in 1d, just how many points should be considered in each direction, so that `word_length = prod(extent)`) and a lag in each direction as `SpatialSymbolicPermutation(extent, lag, x)`, such that
  ```julia
  est = SpatialSymbolicPermutation((2, 2), (2, 2), x)
  ```
  is equivalent to the original
  ```julia
  stencil = CartesianIndex.([(0, 2), (2, 0), (2, 2)])
  est = SpatialSymbolicPermutation(stencil, x)
  ```
- In general, pass n-dimensional `Array`s instead of a list of cartesian indices, where for example
  ```julia
  stencil = [1 0 1;
             0 0 0; 
             1 0 1]
  ```
  would correspond to the cartesian-index version
  ```julia
  stencil = CartesianIndex.([(0, 2), (2, 0), (2, 2)])
  ```