### PR TITLE
Slightly larger edge lengths ensures bins cover all points

### DIFF
--- a/src/probabilities_estimators/histograms/rectangular_binning.jl
+++ b/src/probabilities_estimators/histograms/rectangular_binning.jl
@@ -58,7 +58,7 @@ struct RectangularBinEncoder{M, E} <: SymbolizationScheme
     edgelengths::E
 end
 
-function RectangularBinEncoder(x::AbstractDataset{D,T}, b::RectangularBinning) where {D, T}
+function RectangularBinEncoder(x::AbstractDataset{D,T}, b::RectangularBinning; n_eps = 2) where {D, T}
     # This function always returns static vectors and is type stable
     ϵ = b.ϵ
     mini, maxi = minmaxima(x)
@@ -70,7 +70,7 @@ function RectangularBinEncoder(x::AbstractDataset{D,T}, b::RectangularBinning) w
         # Just taking nextfloat once here isn't enough for bins to cover data when using
         # `encode_as_bin` later, because subtraction and division leads to loss
         # of precision. We need a slightly bigger number, so apply nextfloat twice.
-        edgelengths = nextfloat.(edgeslengths_nonadjusted, 2)
+        edgelengths = nextfloat.(edgeslengths_nonadjusted, n_eps)
     else
         error("Invalid ϵ for binning of a dataset")
     end
@@ -78,7 +78,7 @@ function RectangularBinEncoder(x::AbstractDataset{D,T}, b::RectangularBinning) w
     RectangularBinEncoder(b, mini, edgelengths)
 end
 
-function RectangularBinEncoder(x::AbstractVector{<:Real}, b::RectangularBinning)
+function RectangularBinEncoder(x::AbstractVector{<:Real}, b::RectangularBinning; n_eps = 2)
     # This function always returns numbers and is type stable
     ϵ = b.ϵ
     mini, maxi = extrema(x)
@@ -88,7 +88,7 @@ function RectangularBinEncoder(x::AbstractVector{<:Real}, b::RectangularBinning)
         edgeslength_nonadjusted = (maxi - mini)/ϵ
         # Round-off occurs when encoding bins. Applying `nextfloat` twice seems to still
         # ensure that bins cover data. See comment above.
-        edgelength = nextfloat(edgeslength_nonadjusted, 2)
+        edgelength = nextfloat(edgeslength_nonadjusted, n_eps)
     else
         error("Invalid ϵ for binning of a vector")
     end

--- a/src/probabilities_estimators/histograms/rectangular_binning.jl
+++ b/src/probabilities_estimators/histograms/rectangular_binning.jl
@@ -86,7 +86,7 @@ function RectangularBinEncoder(x::AbstractVector{<:Real}, b::RectangularBinning)
         edgelength = ϵ
     elseif ϵ isa Int
         edgeslength_nonadjusted = (maxi - mini)/ϵ
-        # Round-off occurs when ncoding bins. Applying `nextfloat` twice seems to still
+        # Round-off occurs when encoding bins. Applying `nextfloat` twice seems to still
         # ensure that bins cover data. See comment above.
         edgelength = nextfloat(edgeslength_nonadjusted, 2)
     else

--- a/src/probabilities_estimators/histograms/rectangular_binning.jl
+++ b/src/probabilities_estimators/histograms/rectangular_binning.jl
@@ -67,8 +67,10 @@ function RectangularBinEncoder(x::AbstractDataset{D,T}, b::RectangularBinning) w
         edgelengths = ϵ .* v
     elseif ϵ isa Int || ϵ isa Vector{Int}
         edgeslengths_nonadjusted = @. (maxi - mini)/ϵ
-        # just taking the next float here is enough to ensure boxes cover data
-        edgelengths = nextfloat.(edgeslengths_nonadjusted)
+        # Just taking nextfloat once here isn't enough for bins to cover data when using
+        # `encode_as_bin` later, because subtraction and division leads to loss
+        # of precision. We need a slightly bigger number, so apply nextfloat twice.
+        edgelengths = nextfloat.(edgeslengths_nonadjusted, 2)
     else
         error("Invalid ϵ for binning of a dataset")
     end
@@ -84,8 +86,9 @@ function RectangularBinEncoder(x::AbstractVector{<:Real}, b::RectangularBinning)
         edgelength = ϵ
     elseif ϵ isa Int
         edgeslength_nonadjusted = (maxi - mini)/ϵ
-        # just taking the next float here is enough
-        edgelength = nextfloat(edgeslength_nonadjusted)
+        # Round-off occurs when ncoding bins. Applying `nextfloat` twice seems to still
+        # ensure that bins cover data. See comment above.
+        edgelength = nextfloat(edgeslength_nonadjusted, 2)
     else
         error("Invalid ϵ for binning of a vector")
     end

--- a/test/estimators/visitation_frequency.jl
+++ b/test/estimators/visitation_frequency.jl
@@ -66,9 +66,6 @@ using Random
         x2 = [0.4125754262679051, 0.52844411982339560, 0.4535277505543355, 0.25502420827802674, 0.77862522996085940, 0.6081939026664078, 0.2628674795466387, 0.18846258495465185, 0.93320375283233840, 0.40093871561247874, 0.8032730760974603, 0.3531608285217499, 0.018436525139752136, 0.55541857934068420, 0.9907521337888632, 0.15382361136212420, 0.01774321666660561, 0.67569337507728300, 0.06130971689608822, 0.31417161558476836]
         N = 10
         b = RectangularBinning(N)
-        @test length(probabilities(x1, b)) == N
-        @test length(probabilities(x2, b)) == N
-
         rb1 = RectangularBinEncoder(x1, b, n_eps = 1)
         rb2 = RectangularBinEncoder(x1, b, n_eps = 2)
         @test Entropies.encode_as_bin(maximum(x1), rb1) == 10 # shouldn't occur, but does when tolerance is too low

--- a/test/estimators/visitation_frequency.jl
+++ b/test/estimators/visitation_frequency.jl
@@ -50,4 +50,28 @@ using Random
             @test all(e -> 0.09 ≤ e ≤ 0.11, p)
         end
     end
+
+    # An extra bin might appear due to roundoff error after using nextfloat when
+    # constructing `RectangularBinEncoder`s.
+    # The following tests ensure with *some* certainty that this does not occur.
+    @testset "Rogue extra bins" begin
+        rng = MersenneTwister(1234)
+        xs1D = [rand(rng, 20) for i = 1:10000];
+        xs2D = [rand(rng, 1000, 2) |> Dataset for i = 1:10000] # more points to fill all bins
+        est = ValueHistogram(RectangularBinning(10))
+        ps1D = [probabilities(x, est) for x in xs1D];
+        ps2D = [probabilities(x, est) for x in xs2D];
+        n_rogue_extrabin_1D = count(length.(ps1D) .> est.binning.ϵ)
+        n_rogue_extrabin_2D = count(length.(ps2D) .> est.binning.ϵ^2)
+        @test n_rogue_extrabin_1D == 0
+        @test n_rogue_extrabin_2D == 0
+
+        # Concrete examples where a rogue extra bin has appeared.
+        x1 = [0.5213236385155418, 0.03516318860292644, 0.5437726723245310, 0.52598710966469610, 0.34199879802511246, 0.6017129426606275, 0.6972844365031351, 0.89163995617220900, 0.39009862510518045, 0.06296038912844315, 0.9897176284081909, 0.7935001082966890, 0.890198448900077700, 0.11762640519877565, 0.7849413168095061, 0.13768932585886573, 0.50869900547793430, 0.18042178201388548, 0.28507312391861270, 0.96480406570924970]
+        x2 = [0.4125754262679051, 0.52844411982339560, 0.4535277505543355, 0.25502420827802674, 0.77862522996085940, 0.6081939026664078, 0.2628674795466387, 0.18846258495465185, 0.93320375283233840, 0.40093871561247874, 0.8032730760974603, 0.3531608285217499, 0.018436525139752136, 0.55541857934068420, 0.9907521337888632, 0.15382361136212420, 0.01774321666660561, 0.67569337507728300, 0.06130971689608822, 0.31417161558476836]
+        N = 10
+        b = RectangularBinning(N)
+        @test length(probabilities(x1, b)) == N
+        @test length(probabilities(x2, b)) == N
+    end
 end

--- a/test/estimators/visitation_frequency.jl
+++ b/test/estimators/visitation_frequency.jl
@@ -76,12 +76,12 @@ using Random
 
         rb1 = RectangularBinEncoder(x1, b, n_eps = 1)
         rb2 = RectangularBinEncoder(x1, b, n_eps = 2)
-        @test Entropies.encode_as_bin(maximum(x1), rb1) == 9
+        @test Entropies.encode_as_bin(maximum(x1), rb1) == 10 # shouldn't occur, but does when tolerance is too low
         @test Entropies.encode_as_bin(maximum(x1), rb2) == 9
 
         rb1 = RectangularBinEncoder(x2, b, n_eps = 1)
         rb2 = RectangularBinEncoder(x2, b, n_eps = 2)
-        @test Entropies.encode_as_bin(maximum(x2), rb1) == 9
+        @test_throws Entropies.encode_as_bin(maximum(x2), rb1) == 10 # shouldn't occur, but does when tolerance is too low
         @test Entropies.encode_as_bin(maximum(x2), rb2) == 9
     end
 end

--- a/test/estimators/visitation_frequency.jl
+++ b/test/estimators/visitation_frequency.jl
@@ -73,5 +73,15 @@ using Random
         b = RectangularBinning(N)
         @test length(probabilities(x1, b)) == N
         @test length(probabilities(x2, b)) == N
+
+        rb1 = RectangularBinEncoder(x1, b, n_eps = 1)
+        rb2 = RectangularBinEncoder(x1, b, n_eps = 2)
+        @test Entropies.encode_as_bin(maximum(x1), rb1) == 9
+        @test Entropies.encode_as_bin(maximum(x1), rb2) == 9
+
+        rb1 = RectangularBinEncoder(x2, b, n_eps = 1)
+        rb2 = RectangularBinEncoder(x2, b, n_eps = 2)
+        @test Entropies.encode_as_bin(maximum(x2), rb1) == 9
+        @test Entropies.encode_as_bin(maximum(x2), rb2) == 9
     end
 end

--- a/test/estimators/visitation_frequency.jl
+++ b/test/estimators/visitation_frequency.jl
@@ -76,7 +76,7 @@ using Random
 
         rb1 = RectangularBinEncoder(x2, b, n_eps = 1)
         rb2 = RectangularBinEncoder(x2, b, n_eps = 2)
-        @test_throws Entropies.encode_as_bin(maximum(x2), rb1) == 10 # shouldn't occur, but does when tolerance is too low
+        @test Entropies.encode_as_bin(maximum(x2), rb1) == 10 # shouldn't occur, but does when tolerance is too low
         @test Entropies.encode_as_bin(maximum(x2), rb2) == 9
     end
 


### PR DESCRIPTION
Fixes #128. Increasing bin edge widths by  `1*eps()` seems to be enough to avoid round-off issues in `encode_as_bin`. 

This seems to work when tested experimentally, but a more robust solution is perhaps desired. Any suggestions are welcome.