### PR TITLE
KozachenkoLeonenko estimator should *not* have property `k`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The API for Entropies.jl has been completely overhauled. Major changes are:
 - Many new estimators, such as `SpatialPermutation` and `PowerSpectrum`.
 - Check the online documentation for a comprehensive overview of the changes.
 
+### Bug fixes
+
+- The `KozachenkoLeonenko` estimator now correctly fixes its neighbor search to the
+    *closest* neighbor only, and its constructor does no longer accept `k` as an input.
+
 ## main
 * New probability estimator `SpatialSymbolicPermutation` suitable for computing spatial permutation entropies
 * Introduce Tsallis entropy.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -22,7 +22,7 @@ for N in Ns
     for i = 1:nreps
         pts = Dataset([rand(Uniform(0, 1), 1) for i = 1:N]);
 
-        push!(kl, entropy(KozachenkoLeonenko(w = 0, k = 1, base = MathConstants.e), pts))
+        push!(kl, entropy(KozachenkoLeonenko(w = 0, base = MathConstants.e), pts))
         # with k = 1, Kraskov is virtually identical to
         # Kozachenko-Leonenko, so pick a higher number of neighbors
         push!(kr, entropy(Kraskov(w = 0, k = 3, base = MathConstants.e), pts))

--- a/src/entropies/direct_entropies/nearest_neighbors/KozachenkoLeonenko.jl
+++ b/src/entropies/direct_entropies/nearest_neighbors/KozachenkoLeonenko.jl
@@ -6,15 +6,14 @@ export KozachenkoLeonenko
 
 An indirect entropy estimator used in [`entropy`](@ref)`(KozachenkoLeonenko(), x)` to
 estimate the Shannon entropy of `x` (a multi-dimensional `Dataset`) to the given
-`base` using `k`-th nearest neighbor searches using the method from Kozachenko &
-Leonenko[^KozachenkoLeonenko1987],
-as described in Charzyńska and Gambin[^Charzyńska2016].
+`base` using nearest neighbor searches using the method from Kozachenko &
+Leonenko[^KozachenkoLeonenko1987], as described in Charzyńska and Gambin[^Charzyńska2016].
 
 `w` is the Theiler window, which determines if temporal neighbors are excluded
 during neighbor searches (defaults to `0`, meaning that only the point itself is excluded
 when searching for neighbours).
 
-See also: [`Kraskov`](@ref).
+In contrast to [`Kraskov`](@ref), this estimator uses only the *closest* neighbor.
 
 [^Charzyńska2016]: Charzyńska, A., & Gambin, A. (2016). Improvement of the k-NN entropy
     estimator with applications in systems biology. Entropy, 18(1), 13.
@@ -22,15 +21,14 @@ See also: [`Kraskov`](@ref).
     the entropy of a random vector. Problemy Peredachi Informatsii, 23(2), 9-16.
 """
 @Base.kwdef struct KozachenkoLeonenko{B} <: IndirectEntropy
-    k::Int = 1
     w::Int = 1
     base::B = 2
 end
 
 function entropy(e::KozachenkoLeonenko, x::AbstractDataset{D, T}) where {D, T}
-    (; k, w, base) = e
+    (; w, base) = e
     N = length(x)
-    ρs = maximum_neighbor_distances(x, w, k)
+    ρs = maximum_neighbor_distances(x, w, 1)
     h = D/N*sum(log.(base, ρs)) + log(base, ball_volume(D)) +
         MathConstants.eulergamma + log(base, N - 1)
     return h

--- a/test/entropies/nearest_neighbors_direct.jl
+++ b/test/entropies/nearest_neighbors_direct.jl
@@ -16,7 +16,7 @@ end
     τs = tuple([τ*i for i = 0:m-1]...)
     x = rand(250)
     D = genembed(x, τs)
-    est = KozachenkoLeonenko(k = 3, w = 1)
+    est = KozachenkoLeonenko(w = 1)
 
     @test entropy(est, D) isa Real
 end


### PR DESCRIPTION
In my original implementation for `KozchenkoLeonenko`, I included the number of nearest neighbors `k` as a variable the user could pick freely. However, the estimator from the Kozachenko-Leonenko original paper (as referenced in [Charzyńska et al](https://www.mdpi.com/1099-4300/18/1/13/htm)) does *not* allow picking `k` freely. It explicitly says that the formula is valid for the *nearest* (i.e. closest neighbor). 

In fact, because the formula for the estimator doesn't depend on `k` in any way, picking a `k != 1` would led to entropy estimates that are wildly off. 

I didn't catch this error before, because in all examples I tested and cross-referenced against true values (including the example in our documentation), I always picked `k = 1`.

This PR hard-codes `k = 1` and removes the option for the user to pick it. Docs and tests are updated accordingly.
