### PR TITLE
Correct conversion between logarithm bases for `Kraskov` and `KozachenkoLeonenko`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ The API for Entropies.jl has been completely overhauled. Major changes are:
 - Many new estimators, such as `SpatialPermutation` and `PowerSpectrum`.
 - Check the online documentation for a comprehensive overview of the changes.
 
+### Bug fixes
+
+- The `KozachenkoLeonenko` estimator now correctly fixes its neighbor search to the
+    *closest* neighbor only, and its constructor does no longer accept `k` as an input.
+- Using a logarithm `base` different from `MathConstants.e` now yields correct results
+    for `Kraskov` and `KozachenkoLeonenko`.
+
 ## main
 * New probability estimator `SpatialSymbolicPermutation` suitable for computing spatial permutation entropies
 * Introduce Tsallis entropy.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -22,7 +22,7 @@ for N in Ns
     for i = 1:nreps
         pts = Dataset([rand(Uniform(0, 1), 1) for i = 1:N]);
 
-        push!(kl, entropy(KozachenkoLeonenko(w = 0, k = 1, base = MathConstants.e), pts))
+        push!(kl, entropy(KozachenkoLeonenko(w = 0, base = MathConstants.e), pts))
         # with k = 1, Kraskov is virtually identical to
         # Kozachenko-Leonenko, so pick a higher number of neighbors
         push!(kr, entropy(Kraskov(w = 0, k = 3, base = MathConstants.e), pts))

--- a/src/entropies/direct_entropies/nearest_neighbors/KozachenkoLeonenko.jl
+++ b/src/entropies/direct_entropies/nearest_neighbors/KozachenkoLeonenko.jl
@@ -29,7 +29,10 @@ function entropy(e::KozachenkoLeonenko, x::AbstractDataset{D, T}) where {D, T}
     (; w, base) = e
     N = length(x)
     ρs = maximum_neighbor_distances(x, w, 1)
-    h = D/N*sum(log.(base, ρs)) + log(base, ball_volume(D)) +
-        MathConstants.eulergamma + log(base, N - 1)
-    return h
+    # The estimated entropy has "unit" [nats]
+    h = D/N * sum(log.(MathConstants.e, ρs)) +
+        log(MathConstants.e, ball_volume(D)) +
+        MathConstants.eulergamma +
+        log(MathConstants.e, N - 1)
+    return h / log(base, MathConstants.e) # Convert to target unit
 end

--- a/src/entropies/direct_entropies/nearest_neighbors/KozachenkoLeonenko.jl
+++ b/src/entropies/direct_entropies/nearest_neighbors/KozachenkoLeonenko.jl
@@ -6,15 +6,14 @@ export KozachenkoLeonenko
 
 An indirect entropy estimator used in [`entropy`](@ref)`(KozachenkoLeonenko(), x)` to
 estimate the Shannon entropy of `x` (a multi-dimensional `Dataset`) to the given
-`base` using `k`-th nearest neighbor searches using the method from Kozachenko &
-Leonenko[^KozachenkoLeonenko1987],
-as described in Charzyńska and Gambin[^Charzyńska2016].
+`base` using nearest neighbor searches using the method from Kozachenko &
+Leonenko[^KozachenkoLeonenko1987], as described in Charzyńska and Gambin[^Charzyńska2016].
 
 `w` is the Theiler window, which determines if temporal neighbors are excluded
 during neighbor searches (defaults to `0`, meaning that only the point itself is excluded
 when searching for neighbours).
 
-See also: [`Kraskov`](@ref).
+In contrast to [`Kraskov`](@ref), this estimator uses only the *closest* neighbor.
 
 [^Charzyńska2016]: Charzyńska, A., & Gambin, A. (2016). Improvement of the k-NN entropy
     estimator with applications in systems biology. Entropy, 18(1), 13.
@@ -22,15 +21,14 @@ See also: [`Kraskov`](@ref).
     the entropy of a random vector. Problemy Peredachi Informatsii, 23(2), 9-16.
 """
 @Base.kwdef struct KozachenkoLeonenko{B} <: IndirectEntropy
-    k::Int = 1
     w::Int = 1
     base::B = 2
 end
 
 function entropy(e::KozachenkoLeonenko, x::AbstractDataset{D, T}) where {D, T}
-    (; k, w, base) = e
+    (; w, base) = e
     N = length(x)
-    ρs = maximum_neighbor_distances(x, w, k)
+    ρs = maximum_neighbor_distances(x, w, 1)
     h = D/N*sum(log.(base, ρs)) + log(base, ball_volume(D)) +
         MathConstants.eulergamma + log(base, N - 1)
     return h

--- a/src/entropies/direct_entropies/nearest_neighbors/Kraskov.jl
+++ b/src/entropies/direct_entropies/nearest_neighbors/Kraskov.jl
@@ -28,6 +28,9 @@ function entropy(e::Kraskov, x::AbstractDataset{D, T}) where {D, T}
     (; k, w, base) = e
     N = length(x)
     ρs = maximum_neighbor_distances(x, w, k)
-    h = -digamma(k) + digamma(N) + log(base, ball_volume(D)) + D/N*sum(log.(base, ρs))
-    return h
+    # The estimated entropy has "unit" [nats]
+    h = -digamma(k) + digamma(N) +
+        log(MathConstants.e, ball_volume(D)) +
+        D/N*sum(log.(MathConstants.e, ρs))
+    return h / log(base, MathConstants.e) # Convert to target unit
 end

--- a/test/entropies/nearest_neighbors_direct.jl
+++ b/test/entropies/nearest_neighbors_direct.jl
@@ -16,7 +16,7 @@ end
     τs = tuple([τ*i for i = 0:m-1]...)
     x = rand(250)
     D = genembed(x, τs)
-    est = KozachenkoLeonenko(k = 3, w = 1)
+    est = KozachenkoLeonenko(w = 1)
 
     @test entropy(est, D) isa Real
 end

--- a/test/entropies/nearest_neighbors_direct.jl
+++ b/test/entropies/nearest_neighbors_direct.jl
@@ -8,6 +8,17 @@ using Test
     D = genembed(x, τs)
     est = Kraskov(k = 3, w = 1)
     @test entropy(est, D) isa Real
+
+    # Analytical test.
+    XN = Dataset(randn(100000, 1));
+    # For normal distribution with mean 0 and std 1, the entropy is
+    h_XN_base_e = 0.5 * log(MathConstants.e, 2π) + 0.5 # nats
+    h_XN_base_2 = h_XN_base_e / log(2, MathConstants.e) # bits
+
+    h_XN_kr_base_e = entropy(Kraskov(k = 3, base = MathConstants.e), XN)
+    h_XN_kr_base_2 = entropy(Kraskov(k = 3, base = 2), XN)
+    @test round(h_XN_base_e, digits = 1) == round(h_XN_kr_base_e, digits = 1)
+    @test round(h_XN_base_2, digits = 1) == round(h_XN_kr_base_2, digits = 1)
 end
 
 @testset "NN - KozachenkoLeonenko" begin
@@ -19,4 +30,19 @@ end
     est = KozachenkoLeonenko(w = 1)
 
     @test entropy(est, D) isa Real
+
+    # Analytical test.
+    XN = Dataset(randn(100000, 1));
+    # For normal distribution with mean 0 and std 1, the entropy is
+    h_XN_base_e = 0.5 * log(MathConstants.e, 2π) + 0.5 # nats
+    h_XN_base_2 = h_XN_base_e / log(2, MathConstants.e) # bits
+
+    h_XN_kr_base_e = entropy(KozachenkoLeonenko(base = MathConstants.e), XN)
+    h_XN_kr_base_2 = entropy(KozachenkoLeonenko(base = 2), XN)
+    # The KozachenkoLeonenko estimator is not as precise as Kraskov, so check that we're
+    # within +- 3% of the target value
+    tol_e = h_XN_base_e * 0.03
+    tol_2 = h_XN_base_2 * 0.03
+    @test h_XN_base_e - tol_e ≤ h_XN_kr_base_e ≤ h_XN_base_e + tol_e
+    @test h_XN_base_2 - tol_2 ≤ h_XN_kr_base_2 ≤ h_XN_base_2 + tol_2
 end


### PR DESCRIPTION
This fixes #154 