### PR TITLE
Indirect Zhu et al. kNN Shannon entropy estimator for univariate/multivariate data

### DIFF
--- a/docs/src/entropies.md
+++ b/docs/src/entropies.md
@@ -51,6 +51,7 @@ Here we list functions which compute Shannon entropies via alternate means, with
 ```@docs
 Kraskov
 KozachenkoLeonenko
+Zhu
 ```
 
 ## Convenience functions

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -14,21 +14,24 @@ using Distributions: Uniform, Normal
 Ns = [100:100:500; 1000:1000:10000]
 Ekl = Vector{Vector{Float64}}(undef, 0)
 Ekr = Vector{Vector{Float64}}(undef, 0)
+Ez = Vector{Vector{Float64}}(undef, 0)
 
 nreps = 50
 for N in Ns
     kl = Float64[]
     kr = Float64[]
+    kz = Float64[]
     for i = 1:nreps
         pts = Dataset([rand(Uniform(0, 1), 1) for i = 1:N]);
-
         push!(kl, entropy(KozachenkoLeonenko(w = 0, base = MathConstants.e), pts))
         # with k = 1, Kraskov is virtually identical to
         # Kozachenko-Leonenko, so pick a higher number of neighbors
         push!(kr, entropy(Kraskov(w = 0, k = 3, base = MathConstants.e), pts))
+        push!(kz, entropy(Zhu(w = 0, base = MathConstants.e), pts))
     end
     push!(Ekl, kl)
     push!(Ekr, kr)
+    push!(Ez, kz)
 end
 
 fig = Figure()
@@ -41,6 +44,11 @@ ay = Axis(fig[2,1]; xlabel = "time step", ylabel = "entropy (nats)", title = "Kr
 lines!(ay, Ns, mean.(Ekr); color = Cycled(2))
 band!(ay, Ns, mean.(Ekr) .+ std.(Ekr), mean.(Ekr) .- std.(Ekr);
 color = (Main.COLORS[2], 0.5))
+
+ay = Axis(fig[3,1]; xlabel = "time step", ylabel = "entropy (nats)", title = "Zhu")
+lines!(ay, Ns, mean.(Ez); color = Cycled(2))
+band!(ay, Ns, mean.(Ez) .+ std.(Ez), mean.(Ez) .- std.(Ez);
+color = (Main.COLORS[3], 0.5))
 
 fig
 ```

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -45,9 +45,9 @@ lines!(ay, Ns, mean.(Ekr); color = Cycled(2))
 band!(ay, Ns, mean.(Ekr) .+ std.(Ekr), mean.(Ekr) .- std.(Ekr);
 color = (Main.COLORS[2], 0.5))
 
-ay = Axis(fig[3,1]; xlabel = "time step", ylabel = "entropy (nats)", title = "Zhu")
-lines!(ay, Ns, mean.(Ez); color = Cycled(2))
-band!(ay, Ns, mean.(Ez) .+ std.(Ez), mean.(Ez) .- std.(Ez);
+az = Axis(fig[3,1]; xlabel = "time step", ylabel = "entropy (nats)", title = "Zhu")
+lines!(az, Ns, mean.(Ez); color = Cycled(2))
+band!(az, Ns, mean.(Ez) .+ std.(Ez), mean.(Ez) .- std.(Ez);
 color = (Main.COLORS[3], 0.5))
 
 fig

--- a/src/entropies/direct_entropies/nearest_neighbors/Zhu.jl
+++ b/src/entropies/direct_entropies/nearest_neighbors/Zhu.jl
@@ -1,0 +1,63 @@
+export Zhu
+
+"""
+    Zhu <: IndirectEntropy
+    Zhu(k = 1, w = 1, base = MathConstants.e)
+
+The `Zhu` indirect entropy estimator (Zhu et al., 2015)[^Zhu2015] estimates the Shannon
+entropy of `x` (a multi-dimensional `Dataset`) to the given `base`, by approximating
+probabilities within hyperrectangles surrounding each point `xᵢ ∈ x` using
+using `k` nearest neighbor searches.
+
+This estimator is an extension to [`KozachenkoLeonenko`](@ref).
+
+`w` is the Theiler window, which determines if temporal neighbors are excluded
+during neighbor searches (defaults to `0`, meaning that only the point itself is excluded
+when searching for neighbours).
+
+[^Zhu2015]:
+    Zhu, J., Bellanger, J. J., Shu, H., & Le Bouquin Jeannès, R. (2015). Contribution to
+    transfer entropy estimation via the k-nearest-neighbors approach. Entropy, 17(6),
+    4173-4201.
+"""
+Base.@kwdef struct Zhu{B} <: IndirectEntropy
+    k::Int = 1
+    w::Int = 1
+    base::B = MathConstants.e
+end
+
+"""
+    volume_minirect(xᵢ, nns)
+
+Compute the volume of the minimal enclosing rectangle with `xᵢ` at its center and
+containing all points `nᵢ ∈ nns` either within the rectangle or on one of its borders.
+
+This function respects the coordinate system of the input data, i.e. it does not perform
+any rotation (which would be computationally more demanding because we'd need to find the
+convex hull of `nns`, but could potentially give more accurate results).
+"""
+function volume_minirect(xᵢ, nns::AbstractDataset)
+    mini, maxi = minmaxima(nns)
+    # dists[d] is the maximum distance from the point xᵢ to any neighbor in dimension d
+    # We take twice those distances to ensure xᵢ is at the centre of the rectangle.
+    dists = max.(maxi .- xᵢ, xᵢ .- mini)
+    return prod(dists .* 2)
+end
+
+function mean_logvolumes(x, nn_idxs, N::Int)
+    v = 0.0
+    for (i, (xᵢ, nn_idxsᵢ)) in enumerate(zip(x, nn_idxs))
+        nnsᵢ = @views x[nn_idxsᵢ] # the actual coordinates of the points
+        v += log(MathConstants.e, volume_minirect(xᵢ, nnsᵢ))
+    end
+    return v / N
+end
+
+function entropy(e::Zhu, x::AbstractDataset{D, T}) where {D, T}
+    (; k, w, base) = e
+    N = length(x)
+    tree = KDTree(x, Euclidean())
+    nn_idxs = bulkisearch(tree, x, NeighborNumber(k), Theiler(w))
+    h = digamma(N) + mean_logvolumes(x, nn_idxs, N) - digamma(k) + (D - 1) / k
+    return h / log(base, MathConstants.e)
+end

--- a/src/entropies/direct_entropies/nearest_neighbors/nearest_neighbors.jl
+++ b/src/entropies/direct_entropies/nearest_neighbors/nearest_neighbors.jl
@@ -15,3 +15,4 @@ ball_volume(d::Int) = π^(d/2)/gamma((d/2)+1)
 
 include("KozachenkoLeonenko.jl")
 include("Kraskov.jl")
+include("Zhu.jl")

--- a/test/entropies/nearest_neighbors_direct.jl
+++ b/test/entropies/nearest_neighbors_direct.jl
@@ -20,3 +20,24 @@ end
 
     @test entropy(est, D) isa Real
 end
+
+@testset "NN - Zhu" begin
+
+    # To ensure minimal rectangle volumes are correct, we also test internals directly here.
+    # It's not feasible to construct an end-product test due to the neighbor searches.
+    x = Dataset([[-1, -2], [0, -2], [3, 2]])
+    y = Dataset([[3, 1], [-5, 1], [3, -2]])
+    @test Entropies.volume_minirect([0, 0], x) == 24
+    @test Entropies.volume_minirect([0, 0], y) == 40
+
+    # Analytical tests for the estimated entropy
+    DN = Dataset(randn(200000, 1))
+    hN_base_e = 0.5 * log(MathConstants.e, 2π) + 0.5
+    hN_base_2 = hN_base_e / log(2, MathConstants.e)
+
+    e_base_e = Zhu(k = 3, base = MathConstants.e)
+    e_base_2 = Zhu(k = 3, base = 2)
+
+    @test round(entropy(e_base_e, DN), digits = 1) == round(hN_base_e, digits = 1)
+    @test round(entropy(e_base_2, DN), digits = 1) == round(hN_base_2, digits = 1)
+end


### PR DESCRIPTION
This PR implements the Zhu et al. estimator for Shannon entropy.

Included:
- Documentation entry + example
- Analytical tests using the entropy of the normal distribution

## References

Zhu, J., Bellanger, J. J., Shu, H., & Le Bouquin Jeannès, R. (2015). Contribution to transfer entropy estimation via the k-nearest-neighbors approach. Entropy, 17(6), 4173-4201.