### PR TITLE
WIP: Decode permutation, and `probabilities_and_outcomes` for ordinal permutation estimators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ repo = "https://github.com/juliadynamics/Entropies.jl.git"
 version = "2.0.0"
 
 [deps]
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -20,6 +21,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Wavelets = "29a6e085-ba6d-5f35-a997-948ac2efa89a"
 
 [compat]
+Combinatorics = "1"
 DelayEmbeddings = "2.5"
 Distances = "0.9, 0.10"
 FFTW = "1"

--- a/src/encoding/ordinal_pattern.jl
+++ b/src/encoding/ordinal_pattern.jl
@@ -18,27 +18,27 @@ then encoded to integers using [`encode_motif`](@ref), used with
 # Usage
 
     outcomes(x, scheme::OrdinalPatternEncoding) → Vector{Int}
-    outcomes!(s, x, scheme::OrdinalPatternEncoding) → Vector{Int}
+    outcomes!(πs, x, scheme::OrdinalPatternEncoding) → Vector{Int}
 
 If applied to an `m`-dimensional `Dataset` `x`, then `m` and `τ` are ignored,
 and `m`-dimensional permutation patterns are obtained directly for each
 `xᵢ ∈ x`. Permutation patterns are then encoded as integers using [`encode_motif`](@ref).
-Optionally, symbols can be written directly into a pre-allocated integer vector `s`, where
-`length(s) == length(x)` using `discretize!`.
+Optionally, symbols can be written directly into a pre-allocated integer vector `πs`, where
+`length(πs) == length(x)` using `outcomes!`.
 
 If applied to a univariate vector `x`, then `x` is first converted to a delay
 reconstruction using embedding dimension `m` and lag `τ`. Permutation patterns are then
 computed for each of the resulting `m`-dimensional `xᵢ ∈ x`, and each permutation
 is then encoded as an integer using [`encode_motif`](@ref).
-If using the in-place variant with univariate input, `s` must obey
-`length(s) == length(x)-(est.m-1)*est.τ`.
+If using the in-place variant with univariate input, `πs` must obey
+`length(πs) == length(x)-(est.m-1)*est.τ`.
 
 ## Examples
 
 ```julia
 using DelayEmbeddings, Entropies
 D = Dataset([rand(7) for i = 1:1000])
-s = outcomes(D, OrdinalPatternEncoding())
+πs = outcomes(D, OrdinalPatternEncoding())
 ```
 
 See also: [`outcomes`](@ref).
@@ -49,44 +49,44 @@ Base.@kwdef struct OrdinalPatternEncoding <: Encoding
     lt::Function = isless_rand
 end
 
-function fill_symbolvector!(s, x, sp, m::Int; lt::Function = isless_rand)
+function fill_symbolvector!(πs, x, sp, m::Int; lt::Function = isless_rand)
     @inbounds for i in eachindex(x)
         sortperm!(sp, x[i], lt = lt)
-        s[i] = encode_motif(sp, m)
+        πs[i] = encode_motif(sp, m)
     end
 end
 
 function outcomes(x::AbstractDataset{m, T}, scheme::OrdinalPatternEncoding) where {m, T}
     m >= 2 || error("Data must be at least 2-dimensional to discretize. If data is a univariate time series, embed it using `genembed` first.")
-    s = zeros(Int, length(x))
-    outcomes!(s, x, scheme)
-    return s
+    πs = zeros(Int, length(x))
+    outcomes!(πs, x, scheme)
+    return πs
 end
 
 function outcomes(x::AbstractVector{T}, scheme::OrdinalPatternEncoding) where {T}
     τs = tuple([scheme.τ*i for i = 0:scheme.m-1]...)
     x_emb = genembed(x, τs)
 
-    s = zeros(Int, length(x_emb))
-    outcomes!(s, x_emb, scheme)
-    return s
+    πs = zeros(Int, length(x_emb))
+    outcomes!(πs, x_emb, scheme)
+    return πs
 end
 
-function outcomes!(s::AbstractVector{Int}, x::AbstractDataset{m, T},
+function outcomes!(πs::AbstractVector{Int}, x::AbstractDataset{m, T},
         scheme::OrdinalPatternEncoding) where {m, T}
 
-    @assert length(s) == length(x)
+    @assert length(πs) == length(x)
 
     sp = zeros(Int, m) # pre-allocate a single-symbol vector that can be overwritten.
-    fill_symbolvector!(s, x, sp, m, lt = scheme.lt)
+    fill_symbolvector!(πs, x, sp, m, lt = scheme.lt)
 
-    return s
+    return πs
 end
 
-function outcomes!(s::AbstractVector{Int}, x::AbstractVector{T},
+function outcomes!(πs::AbstractVector{Int}, x::AbstractVector{T},
         scheme::OrdinalPatternEncoding) where T
 
     τs = tuple([scheme.τ*i for i = 0:scheme.m-1]...)
     x_emb = genembed(x, τs)
-    outcomes!(s, x_emb, scheme)
+    outcomes!(πs, x_emb, scheme)
 end

--- a/src/encoding/utils.jl
+++ b/src/encoding/utils.jl
@@ -41,9 +41,9 @@ function isless_rand(a, b)
     end
 end
 
-# This is slow. I couldn't find any efficient algorithm in the literature for converting
+# I couldn't find any efficient algorithm in the literature for converting
 # between factorial number system representations and Lehmer codes, so we'll just have to
-# use this naive approach for now.
+# use this naive approach for now. It is probably possible to do this in a faster way.
 """
     decode_motif(s::Int, m::Int) → SVector{m, Int}
 

--- a/src/encoding/utils.jl
+++ b/src/encoding/utils.jl
@@ -2,7 +2,7 @@
     encode_motif(x, m::Int = length(x)) → s::Int
 
 Encode the length-`m` motif `x` (a vector of indices that would sort some vector `v`
-in ascending order) into its unique integer symbol ``s \\in \\{1, 2, \\ldots, m - 1 \\}``,
+in ascending order) into its unique integer symbol ``s \\in \\{0, 1, \\ldots, m - 1 \\}``,
 using Algorithm 1 in Berger et al. (2019)[^Berger2019].
 
 ## Example
@@ -39,4 +39,93 @@ function isless_rand(a, b)
     else
         false
     end
+end
+
+# This is slow. I couldn't find any efficient algorithm in the literature for converting
+# between factorial number system representations and Lehmer codes, so we'll just have to
+# use this naive approach for now.
+"""
+    decode_motif(s::Int, m::Int) → SVector{m, Int}
+
+Given the integer `s`, which is an encoding of the `m`-element ordinal permutation `π`
+based on Lehmer codes, computed using [`encode_motif`](@ref),
+compute the original permutation (a permutation of the numbers `1, 2, …, m`).
+
+## Example
+
+```jldoctest
+julia> using Entropies
+
+julia> x = [1.2, 5.4, 2.2, 1.1]; m = length(x);
+
+julia> xs = sortperm(x) # [4, 1, 3, 2]
+4-element Vector{Int64}:
+ 4
+ 1
+ 3
+ 2
+
+julia> s = encode_motif(xs, m)
+19
+
+julia> decode_motif(19, m)
+4-element SVector{4, Int64} with indices SOneTo(4):
+ 4
+ 1
+ 3
+ 2
+```
+"""
+function decode_motif(s::Int, m::Int)
+    # Convert integer to its factorial number representation. Each factorial number
+    # corresponds to a unique permutation of the numbers `1, 2, ..., m`.
+    f = base10_to_factorial(s, m)
+
+    # Reconstruct the permutation from the factorial representation
+    xs = 1:m |> collect
+    perm = zeros(MVector{m, Int})
+    for i = 1:m
+        perm[i] = popat!(xs, f[i] + 1)
+    end
+
+    return SVector{m, Int}(perm) # converting from SVector to MVector is essentially free
+end
+
+"""
+    base10_to_factorial(s::Int,
+        ndigits::Int = ndigits_in_factorial_base(s)) → f::SVector{ndigits, Int}
+
+Convert a base-10 integer to its factorial number system representation. `f` is a
+vector where `f[k]` is the multiplier of `factorial(k - 1)`.
+
+For example, the base-10 integer `567`, in the factorial number system, is
+``4\\cdot 5! + 3\\cdot 4! + 2\\cdot 3! + 1\\cdot 2! + 1\\cdot 1! + 0\\cdot 0!``.
+For this example, `base10_to_factorial` would return the `SVector` `[4, 3, 2, 1, 1, 0]`.
+
+`ndigits` fixes the number of digits in `f` (this just prepends a zero to `f` for each
+extraneous radix/base). This is useful when using factorial number for decoding Lehmer codes
+into permutations
+"""
+function base10_to_factorial(s::Int, ndigits::Int = ndigits_in_factorial_base(s))
+    remainders = zeros(MVector{ndigits, Int})
+    q = s ÷ 1
+    r = s % 1
+    remainders[end] = r
+    for k = 2:ndigits
+        r = q % k
+        q = q ÷ k
+        remainders[end - k + 1] = r
+    end
+
+    return SVector{ndigits, Int}(remainders)
+end
+
+
+""" Compute how many digits a base-10 integer needs in the factorial number system. """
+function ndigits_in_factorial_base(n::Int)
+    k = 1
+    while factorial(k) < n
+        k += 1
+    end
+    return k
 end

--- a/src/probabilities_estimators/permutation_ordinal/SymbolicAmplitudeAware.jl
+++ b/src/probabilities_estimators/permutation_ordinal/SymbolicAmplitudeAware.jl
@@ -6,11 +6,12 @@ export SymbolicAmplitudeAwarePermutation
 A variant of [`SymbolicPermutation`](@ref) that also incorporates amplitude information,
 based on the amplitude-aware permutation entropy (Azami & Escudero, 2016).
 
-## Outcomes
+## Outcome space
 
 Like for [`SymbolicPermutation`](@ref), the outcome space `Ω` for
-`SymbolicAmplitudeAwarePermutation` is the set `{1, 2, …, factorial(m)}`, where each integer
-correspond to a unique ordinal pattern.
+`SymbolicAmplitudeAwarePermutation` is the lexiographically ordered set of
+length-`m` ordinal patterns (i.e. permutations) that can be formed by the integers
+`1, 2, …, m`. There are `factorial(m)` such patterns.
 
 ## Description
 
@@ -76,7 +77,7 @@ function probabilities_and_outcomes(x::AbstractDataset{m, T},
     πs = outcomes(x, OrdinalPatternEncoding(m = m, lt = est.lt)) # motif length controlled by dimension of input data
     wts = AAPE.(x.data, A = est.A, m = est.m)
     probs = symprobs(πs, wts, normalize = true)
-    observed_outcomes = sort(unique(πs))
+    observed_outcomes = outcome_space(est)[sort(unique(πs))]
 
     return Probabilities(probs), observed_outcomes
 end
@@ -88,9 +89,10 @@ function probabilities_and_outcomes(x::AbstractVector{T},
     πs = outcomes(emb, OrdinalPatternEncoding(m = est.m, lt = est.lt))  # motif length controlled by estimator m
     wts = AAPE.(emb.data, A = est.A, m = est.m)
     probs = symprobs(πs, wts, normalize = true)
-    observed_outcomes = sort(unique(πs))
+    observed_outcomes = outcome_space(est)[sort(unique(πs))]
 
     return Probabilities(probs), observed_outcomes
 end
 
 total_outcomes(est::SymbolicAmplitudeAwarePermutation)::Int = factorial(est.m)
+outcome_space(est::SymbolicAmplitudeAwarePermutation) = permutations(1:est.m) |> collect

--- a/src/probabilities_estimators/permutation_ordinal/SymbolicAmplitudeAware.jl
+++ b/src/probabilities_estimators/permutation_ordinal/SymbolicAmplitudeAware.jl
@@ -74,22 +74,34 @@ end
 
 function probabilities_and_outcomes(x::AbstractDataset{m, T},
         est::SymbolicAmplitudeAwarePermutation) where {m, T}
-    πs = outcomes(x, OrdinalPatternEncoding(m = m, lt = est.lt)) # motif length controlled by dimension of input data
+    πs = outcomes(x, OrdinalPatternEncoding(m = m, lt = est.lt))
     wts = AAPE.(x.data, A = est.A, m = est.m)
     probs = symprobs(πs, wts, normalize = true)
-    observed_outcomes = outcome_space(est)[sort(unique(πs)) .+ 1] # +1 for 0 indexed πs
+
+    # The observed integer encodings are in the set `{0, 1, ..., factorial(m)}`, and each
+    # integer corresponds to a unique permutation. Decoding an integer gives the original
+    # permutation as a `SVector{m, Int}`.
+    observed_encodings = sort(unique(πs))
+    observed_outcomes = decode_motif.(observed_encodings, est.m)
 
     return Probabilities(probs), observed_outcomes
 end
 
 function probabilities_and_outcomes(x::AbstractVector{T},
         est::SymbolicAmplitudeAwarePermutation) where {T<:Real}
+    # We need to manually embed here instead of just calling the method above,
+    # because the embedding vectors are needed to compute weights.
     τs = tuple([est.τ*i for i = 0:est.m-1]...)
     emb = genembed(x, τs)
-    πs = outcomes(emb, OrdinalPatternEncoding(m = est.m, lt = est.lt))  # motif length controlled by estimator m
+    πs = outcomes(emb, OrdinalPatternEncoding(m = est.m, lt = est.lt))
     wts = AAPE.(emb.data, A = est.A, m = est.m)
     probs = symprobs(πs, wts, normalize = true)
-    observed_outcomes = outcome_space(est)[sort(unique(πs)) .+ 1] # +1 for 0 indexed πs
+
+    # The observed integer encodings are in the set `{0, 1, ..., factorial(m)}`, and each
+    # integer corresponds to a unique permutation. Decoding an integer gives the original
+    # permutation as a `SVector{m, Int}`.
+    observed_encodings = sort(unique(πs))
+    observed_outcomes = decode_motif.(observed_encodings, est.m)
 
     return Probabilities(probs), observed_outcomes
 end

--- a/src/probabilities_estimators/permutation_ordinal/SymbolicAmplitudeAware.jl
+++ b/src/probabilities_estimators/permutation_ordinal/SymbolicAmplitudeAware.jl
@@ -77,7 +77,7 @@ function probabilities_and_outcomes(x::AbstractDataset{m, T},
     πs = outcomes(x, OrdinalPatternEncoding(m = m, lt = est.lt)) # motif length controlled by dimension of input data
     wts = AAPE.(x.data, A = est.A, m = est.m)
     probs = symprobs(πs, wts, normalize = true)
-    observed_outcomes = outcome_space(est)[sort(unique(πs))]
+    observed_outcomes = outcome_space(est)[sort(unique(πs)) .+ 1] # +1 for 0 indexed πs
 
     return Probabilities(probs), observed_outcomes
 end
@@ -89,7 +89,7 @@ function probabilities_and_outcomes(x::AbstractVector{T},
     πs = outcomes(emb, OrdinalPatternEncoding(m = est.m, lt = est.lt))  # motif length controlled by estimator m
     wts = AAPE.(emb.data, A = est.A, m = est.m)
     probs = symprobs(πs, wts, normalize = true)
-    observed_outcomes = outcome_space(est)[sort(unique(πs))]
+    observed_outcomes = outcome_space(est)[sort(unique(πs)) .+ 1] # +1 for 0 indexed πs
 
     return Probabilities(probs), observed_outcomes
 end

--- a/src/probabilities_estimators/permutation_ordinal/SymbolicPermutation.jl
+++ b/src/probabilities_estimators/permutation_ordinal/SymbolicPermutation.jl
@@ -104,7 +104,7 @@ function probabilities_and_outcomes(x::AbstractDataset{m, T},
         est::SymbolicPermutation) where {m, T}
     πs = zeros(Int, length(x))
     probs = probabilities!(πs, x, est)
-    observed_outcomes = outcome_space(est)[sort(unique(πs))]
+    observed_outcomes = outcome_space(est)[sort(unique(πs)) .+ 1] # +1 for 0 indexed πs
     probs, observed_outcomes
 end
 
@@ -116,7 +116,7 @@ function probabilities_and_outcomes(x::AbstractVector{T},
     # Create symbol vector and fill it.
     πs = zeros(Int, length(x_emb))
     probs = probabilities!(πs, x_emb, est)
-    observed_outcomes = outcome_space(est)[sort(unique(πs))]
+    observed_outcomes = outcome_space(est)[sort(unique(πs)) .+ 1] # +1 for 0 indexed πs
 
     return probs, observed_outcomes
 end

--- a/src/probabilities_estimators/permutation_ordinal/SymbolicPermutation.jl
+++ b/src/probabilities_estimators/permutation_ordinal/SymbolicPermutation.jl
@@ -1,3 +1,5 @@
+using Combinatorics: permutations
+
 export SymbolicPermutation
 
 """
@@ -17,11 +19,11 @@ embedding delay `τ` and dimension `m`, and then converted to a symbol time seri
 estimated. If applied to a `Dataset`, then `τ` and `m` are ignored, and probabilities are
 computed directly from the state vectors.
 
-## Outcomes
+## Outcome space
 
-The outcomes `Ω` for `SymbolicPermutation` is the set `{1, 2, …, factorial(m)}`,
-where each integer correspond to a unique ordinal pattern, but
-[`probabilities_and_outcomes`](@ref) is not yet implemented for this estimator.
+The outcome space `Ω` for `SymbolicPermutation` is the set of length-`m` ordinal
+patterns (i.e. permutations) that can be formed by the integers `1, 2, …, m`,
+ordered lexicographically. There are `factorial(m)` such patterns.
 
 ## In-place symbolization
 
@@ -102,8 +104,7 @@ function probabilities_and_outcomes(x::AbstractDataset{m, T},
         est::SymbolicPermutation) where {m, T}
     πs = zeros(Int, length(x))
     probs = probabilities!(πs, x, est)
-    observed_outcomes = sort(unique(πs))
-
+    observed_outcomes = outcome_space(est)[sort(unique(πs))]
     probs, observed_outcomes
 end
 
@@ -115,7 +116,7 @@ function probabilities_and_outcomes(x::AbstractVector{T},
     # Create symbol vector and fill it.
     πs = zeros(Int, length(x_emb))
     probs = probabilities!(πs, x_emb, est)
-    observed_outcomes = sort(unique(πs))
+    observed_outcomes = outcome_space(est)[sort(unique(πs))]
 
     return probs, observed_outcomes
 end
@@ -147,3 +148,4 @@ function entropy!(e::Entropy,
 end
 
 total_outcomes(est::SymbolicPermutation)::Int = factorial(est.m)
+outcome_space(est::SymbolicPermutation) = permutations(1:est.m) |> collect

--- a/src/probabilities_estimators/permutation_ordinal/SymbolicWeightedPermutation.jl
+++ b/src/probabilities_estimators/permutation_ordinal/SymbolicWeightedPermutation.jl
@@ -9,11 +9,12 @@ export SymbolicWeightedPermutation
 A variant of [`SymbolicPermutation`](@ref) that also incorporates amplitude information,
 based on the weighted permutation entropy (Fadlallah et al., 2013).
 
-## Outcomes
+## Outcome space
 
 Like for [`SymbolicPermutation`](@ref), the outcome space `Ω` for
-`SymbolicWeightedPermutation` is the set `{1, 2, …, factorial(m)}`, where each integer
-correspond to a unique ordinal pattern.
+`SymbolicWeightedPermutation` is the lexiographically ordered set of
+length-`m` ordinal patterns (i.e. permutations) that can be formed by the integers
+`1, 2, …, m`. There are `factorial(m)` such patterns.
 
 ## Description
 
@@ -90,7 +91,7 @@ function probabilities_and_outcomes(x::AbstractDataset{m, T},
     πs = outcomes(x, OrdinalPatternEncoding(m = m, lt = est.lt))  # motif length controlled by dimension of input data
     wts = weights_from_variance.(x.data, m)
     probs = symprobs(πs, wts, normalize = true)
-    observed_outcomes = sort(unique(πs))
+    observed_outcomes = outcome_space(est)[sort(unique(πs))]
 
    return Probabilities(probs), observed_outcomes
 end
@@ -102,9 +103,10 @@ function probabilities_and_outcomes(x::AbstractVector{T},
     πs = outcomes(emb, OrdinalPatternEncoding(m = est.m, lt = est.lt)) # motif length controlled by estimator m
     wts = weights_from_variance.(emb.data, est.m)
     probs = symprobs(πs, wts, normalize = true)
-    observed_outcomes = sort(unique(πs))
+    observed_outcomes = outcome_space(est)[sort(unique(πs))]
 
     return Probabilities(probs), observed_outcomes
 end
 
 total_outcomes(est::SymbolicWeightedPermutation)::Int = factorial(est.m)
+outcome_space(est::SymbolicWeightedPermutation) = permutations(1:est.m) |> collect

--- a/src/probabilities_estimators/permutation_ordinal/SymbolicWeightedPermutation.jl
+++ b/src/probabilities_estimators/permutation_ordinal/SymbolicWeightedPermutation.jl
@@ -91,19 +91,31 @@ function probabilities_and_outcomes(x::AbstractDataset{m, T},
     πs = outcomes(x, OrdinalPatternEncoding(m = m, lt = est.lt))  # motif length controlled by dimension of input data
     wts = weights_from_variance.(x.data, m)
     probs = symprobs(πs, wts, normalize = true)
-    observed_outcomes = outcome_space(est)[sort(unique(πs)) .+ 1] # +1 for 0 indexed πs
+
+    # The observed integer encodings are in the set `{0, 1, ..., factorial(m)}`, and each
+    # integer corresponds to a unique permutation. Decoding an integer gives the original
+    # permutation as a `SVector{m, Int}`.
+    observed_encodings = sort(unique(πs))
+    observed_outcomes = decode_motif.(observed_encodings, est.m)
 
    return Probabilities(probs), observed_outcomes
 end
 
 function probabilities_and_outcomes(x::AbstractVector{T},
         est::SymbolicWeightedPermutation) where {T<:Real}
+    # We need to manually embed here instead of just calling the method above,
+    # because the embedding vectors are needed to compute weights.
     τs = tuple([est.τ*i for i = 0:est.m-1]...)
     emb = genembed(x, τs)
-    πs = outcomes(emb, OrdinalPatternEncoding(m = est.m, lt = est.lt)) # motif length controlled by estimator m
+    πs = outcomes(x, OrdinalPatternEncoding(m = est.m, lt = est.lt)) # motif length controlled by estimator m
     wts = weights_from_variance.(emb.data, est.m)
     probs = symprobs(πs, wts, normalize = true)
-    observed_outcomes = outcome_space(est)[sort(unique(πs)) .+ 1] # +1 for 0 indexed πs
+
+    # The observed integer encodings are in the set `{0, 1, ..., factorial(m)}`, and each
+    # integer corresponds to a unique permutation. Decoding an integer gives the original
+    # permutation as a `SVector{m, Int}`.
+    observed_encodings = sort(unique(πs))
+    observed_outcomes = decode_motif.(observed_encodings, est.m)
 
     return Probabilities(probs), observed_outcomes
 end

--- a/src/probabilities_estimators/permutation_ordinal/SymbolicWeightedPermutation.jl
+++ b/src/probabilities_estimators/permutation_ordinal/SymbolicWeightedPermutation.jl
@@ -91,7 +91,7 @@ function probabilities_and_outcomes(x::AbstractDataset{m, T},
     πs = outcomes(x, OrdinalPatternEncoding(m = m, lt = est.lt))  # motif length controlled by dimension of input data
     wts = weights_from_variance.(x.data, m)
     probs = symprobs(πs, wts, normalize = true)
-    observed_outcomes = outcome_space(est)[sort(unique(πs))]
+    observed_outcomes = outcome_space(est)[sort(unique(πs)) .+ 1] # +1 for 0 indexed πs
 
    return Probabilities(probs), observed_outcomes
 end
@@ -103,7 +103,7 @@ function probabilities_and_outcomes(x::AbstractVector{T},
     πs = outcomes(emb, OrdinalPatternEncoding(m = est.m, lt = est.lt)) # motif length controlled by estimator m
     wts = weights_from_variance.(emb.data, est.m)
     probs = symprobs(πs, wts, normalize = true)
-    observed_outcomes = outcome_space(est)[sort(unique(πs))]
+    observed_outcomes = outcome_space(est)[sort(unique(πs)) .+ 1] # +1 for 0 indexed πs
 
     return Probabilities(probs), observed_outcomes
 end

--- a/test/estimators/permutation.jl
+++ b/test/estimators/permutation.jl
@@ -83,3 +83,14 @@ est = SymbolicPermutation(m = 2, lt = Base.isless)
 probs, πs = probabilities_and_outcomes(x, est)
 @test πs == [0, 1]
 @test probs == [3/5, 2/5]
+
+est3 = SymbolicPermutation(m = 3)
+@test outcome_space(est3) == [
+    [1, 2, 3],
+    [1, 3, 2],
+    [2, 1, 3],
+    [2, 3, 1],
+    [3, 1, 2],
+    [3, 2, 1],
+]
+@test total_outcomes(est3) == factorial(est3.m)

--- a/test/estimators/permutation.jl
+++ b/test/estimators/permutation.jl
@@ -81,7 +81,7 @@ x = [1, 2, 1, 2, 1, 2]
 # don't randomize in the case of equal values, so use Base.isless
 est = SymbolicPermutation(m = 2, lt = Base.isless)
 probs, πs = probabilities_and_outcomes(x, est)
-@test πs == [0, 1]
+@test πs == SVector{2, Int}.([[1, 2], [2, 1]])
 @test probs == [3/5, 2/5]
 
 est3 = SymbolicPermutation(m = 3)

--- a/test/estimators/permutation_amplitude_aware.jl
+++ b/test/estimators/permutation_amplitude_aware.jl
@@ -44,7 +44,7 @@ x = [1, 2, 1, 2, 1, 2]
 # don't randomize in the case of equal values, so use Base.isless
 est = SymbolicAmplitudeAwarePermutation(m = 2, lt = Base.isless)
 probs, πs = probabilities_and_outcomes(x, est)
-@test πs == [0, 1]
+@test πs == SVector{2, Int}.([[1, 2], [2, 1]])
 
 # TODO: probabilities should be explicitly tested too.
 est3 = SymbolicAmplitudeAwarePermutation(m = 3)

--- a/test/estimators/permutation_amplitude_aware.jl
+++ b/test/estimators/permutation_amplitude_aware.jl
@@ -42,7 +42,18 @@ end
 # [2, 1] => 2
 x = [1, 2, 1, 2, 1, 2]
 # don't randomize in the case of equal values, so use Base.isless
-est = SymbolicWeightedPermutation(m = 2, lt = Base.isless)
+est = SymbolicAmplitudeAwarePermutation(m = 2, lt = Base.isless)
 probs, πs = probabilities_and_outcomes(x, est)
 @test πs == [0, 1]
+
 # TODO: probabilities should be explicitly tested too.
+est3 = SymbolicAmplitudeAwarePermutation(m = 3)
+@test outcome_space(est3) == [
+    [1, 2, 3],
+    [1, 3, 2],
+    [2, 1, 3],
+    [2, 3, 1],
+    [3, 1, 2],
+    [3, 2, 1],
+]
+@test total_outcomes(est3) == factorial(est3.m)

--- a/test/estimators/permutation_weighted.jl
+++ b/test/estimators/permutation_weighted.jl
@@ -45,7 +45,7 @@ x = [1, 2, 1, 2, 1, 2]
 # don't randomize in the case of equal values, so use Base.isless
 est = SymbolicWeightedPermutation(m = 2, lt = Base.isless)
 probs, πs = probabilities_and_outcomes(x, est)
-@test πs == [0, 1]
+@test πs == SVector{2, Int}.([[1, 2], [2, 1]])
 # TODO: probabilities should be explicitly tested too.
 
 est3 = SymbolicWeightedPermutation(m = 3)

--- a/test/estimators/permutation_weighted.jl
+++ b/test/estimators/permutation_weighted.jl
@@ -47,3 +47,14 @@ est = SymbolicWeightedPermutation(m = 2, lt = Base.isless)
 probs, πs = probabilities_and_outcomes(x, est)
 @test πs == [0, 1]
 # TODO: probabilities should be explicitly tested too.
+
+est3 = SymbolicWeightedPermutation(m = 3)
+@test outcome_space(est3) == [
+    [1, 2, 3],
+    [1, 3, 2],
+    [2, 1, 3],
+    [2, 3, 1],
+    [3, 1, 2],
+    [3, 2, 1],
+]
+@test total_outcomes(est3) == factorial(est3.m)

--- a/test/utils/encoding.jl
+++ b/test/utils/encoding.jl
@@ -1,10 +1,8 @@
 using DelayEmbeddings: genembed, Dataset
 using StaticArrays: SVector
+using Entropies: encode_motif, decode_motif
 
 @testset "Ordinal patterns" begin
-    @test Entropies.encode_motif([2, 3, 1]) isa Int
-    @test 0 <= Entropies.encode_motif([2, 3, 1]) <= factorial(3) - 1
-
     scheme = OrdinalPatternEncoding(m = 5, τ = 1)
     N = 100
     x = Dataset(repeat([1.1 2.2 3.3], N))
@@ -34,6 +32,30 @@ using StaticArrays: SVector
     D = Dataset(rand(N, m))
     s = fill(-1, length(D))
     @test all(0 .<= Entropies.outcomes!(s, D, scheme) .< factorial(m))
+
+    # This is not part of the public API, but this is crucial to test directly to
+    # ensure its correctness. It makes no sense to test it though "end-product" code,
+    # because there would be no obvious way of debugging the forward/inverse Lehmer-code
+    # code from end-product code. We therefore test the internals here.
+    @testset "Encoding/decoding" begin
+        m = 4
+        # All possible permutations for length-4 vectors.
+        πs = [
+            [1, 2, 3, 4], [1, 2, 4, 3], [1, 3, 2, 4], [1, 3, 4, 2], [1, 4, 2, 3],
+            [1, 4, 3, 2], [2, 1, 3, 4], [2, 1, 4, 3], [2, 3, 1, 4], [2, 3, 4, 1],
+            [2, 4, 1, 3], [2, 4, 3, 1], [3, 1, 2, 4], [3, 1, 4, 2], [3, 2, 1, 4],
+            [3, 2, 4, 1], [3, 4, 1, 2], [3, 4, 2, 1], [4, 1, 2, 3], [4, 1, 3, 2],
+            [4, 2, 1, 3], [4, 2, 3, 1], [4, 3, 1, 2], [4, 3, 2, 1]
+        ]
+        encoded_πs = encode_motif.(πs, m)
+        @test encoded_πs == 0:(factorial(m) - 1) |> collect
+        @test all(isa.(encoded_πs, Int))
+
+        # Decoded permutations (`SVector{m, Int}`s)
+        decoded_πs = decode_motif.(encoded_πs, m)
+        @test all(length.(decoded_πs) .== m)
+        @test all(decoded_πs .== πs)
+    end
 end
 
 @testset "Gaussian symbolization" begin


### PR DESCRIPTION
Fixes #87.

Take-away:

- The outcome space for a permutation-based methods with parameter/dimension  `m` is

  ```julia
  using Combinatorics
  est = SymbolicPermutation(m = 3)
  outcome_space = permutations(1:est.m) |> collect
  ```
- Each element in outcome space (`{π1, π2, ...., πfactorial(m)}`) is encoded to an integer `s(π) ∈ 0, 1, ..., factorial(m) - 1`.
- Decoding any of these integers with `decode(s, m)` yields the original permutation `π(s) ∈ outcome_space`.
