### PR TITLE
Finish API

### DIFF
--- a/src/encoding/ordinal_pattern.jl
+++ b/src/encoding/ordinal_pattern.jl
@@ -1,12 +1,13 @@
 export OrdinalPatternEncoding
+#TODO: The docstring here, and probably the source code, needs a full re-write
+# based on new `encode` interface.
 
 """
     OrdinalPatternEncoding <: Encoding
     OrdinalPatternEncoding(m = 3, τ = 1; lt = est.lt)
 
 A encoding scheme that converts the input time series to ordinal patterns, which are
-then encoded to integers using [`encode_motif`](@ref), used with
-[`outcomes`](@ref).
+then encoded to integers using [`encode`](@ref).
 
 !!! note
     `OrdinalPatternEncoding` is intended for symbolizing *time series*. If providing a short vector,

--- a/src/encodings.jl
+++ b/src/encodings.jl
@@ -17,16 +17,16 @@ Current available encodings are:
 abstract type Encoding end
 
 """
-    encode(χ, c::Encoding) -> i::Int
+    encode(c::Encoding, χ) -> i::Int
 Encoding an element `χ ∈ x` of input data `x` (those given to [`probabilities`](@ref))
 using encoding `c`. The special value of `-1` is reserved as a return value for
-inappropriate elements `χ` that cannot be encoded according to `e`.
+inappropriate elements `χ` that cannot be encoded according to `c`.
 """
 function encode end
 
 """
-    decode(i::Int, c::Encoding) -> ω
-Decode an encoded element `i::Int` into the outcome it corresponds to `ω ∈ Ω`.
+    decode(c::Encoding, i::Int) -> ω
+Decode an encoded element `i` into the outcome it corresponds to `ω ∈ Ω`.
 `Ω` is the [`outcome_space`](@ref) of a probabilities estimator that uses encoding `c`.
 """
 function decode end

--- a/src/encodings.jl
+++ b/src/encodings.jl
@@ -17,16 +17,16 @@ Current available encodings are:
 abstract type Encoding end
 
 """
-    encode(χ, e::Encoding) -> i::Int
+    encode(χ, c::Encoding) -> i::Int
 Encoding an element `χ ∈ x` of input data `x` (those given to [`probabilities`](@ref))
-using encoding `e`. The special value of `-1` is reserved as a return value for
+using encoding `c`. The special value of `-1` is reserved as a return value for
 inappropriate elements `χ` that cannot be encoded according to `e`.
 """
 function encode end
 
 """
-    decode(i::Int, e::Encoding) -> ω
+    decode(i::Int, c::Encoding) -> ω
 Decode an encoded element `i::Int` into the outcome it corresponds to `ω ∈ Ω`.
-`Ω` is the [`outcome_space`](@ref) of a probabilities estimator that uses encoding `e`.
+`Ω` is the [`outcome_space`](@ref) of a probabilities estimator that uses encoding `c`.
 """
 function decode end

--- a/src/encodings.jl
+++ b/src/encodings.jl
@@ -3,8 +3,8 @@ export Encoding, encode, decode
 """
     Encoding
 
-The supertype for all encoding schemes. Encodings **always encode elements of
-input data into the positive integers**. The encoding API is defined by the
+The supertype for all encoding schemes. Encodings always encode elements of
+input data into the positive integers. The encoding API is defined by the
 functions [`encode`](@ref) and [`decode`](@ref).
 Some probability estimators utilize encodings internally.
 
@@ -19,7 +19,8 @@ abstract type Encoding end
 """
     encode(χ, e::Encoding) -> i::Int
 Encoding an element `χ ∈ x` of input data `x` (those given to [`probabilities`](@ref))
-using encoding `e`.
+using encoding `e`. The special value of `-1` is reserved as a return value for
+inappropriate elements `χ` that cannot be encoded according to `e`.
 """
 function encode end
 

--- a/src/entropies/convenience_definitions.jl
+++ b/src/entropies/convenience_definitions.jl
@@ -58,7 +58,7 @@ entropy(Shannon(base), est, x)
 See [`WaveletOverlap`](@ref) for more info.
 """
 function entropy_wavelet(x; wavelet = Wavelets.WT.Daubechies{12}(), base = 2)
-    est = WaveletOverlap(wavelet)
+    est = WaveletOverlap(x, wavelet)
     entropy(Shannon(; base), est, x)
 end
 

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -60,8 +60,8 @@ abstract type EntropyEstimator <: AbstractEntropy end
     entropy([e::Entropy,] est::ProbabilitiesEstimator, x)
     entropy([e::Entropy,] est::EntropyEstimator, x)
 
-Compute `h`, with `h::Real ∈ [0, ∞)`, which is
-a (generalized) [`Entropy`](@ref) of type `e`, in one of three ways:
+Compute `h::Real`, which is
+a (generalized) entropy defined by `e`, in one of three ways:
 
 1. Directly from existing [`Probabilities`](@ref) `probs`.
 2. From input data `x`, by first estimating a probability distribution using the provided

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -21,12 +21,11 @@ These entropy types are given as inputs to [`entropy`](@ref) and [`entropy_norma
 
 Mathematically speaking, generalized entropies are just nonnegative functions of
 probability distributions that verify certain (entropy-type-dependent) axioms.
-Amigó et al., 2018's
-[summary paper](https://www.mdpi.com/1099-4300/20/11/813) gives a nice overview.
+Amigó et al.[^Amigó2018] summary paper gives a nice overview.
 
 [Amigó2018]:
     Amigó, J. M., Balogh, S. G., & Hernández, S. (2018). A brief review of
-    generalized entropies. Entropy, 20(11), 813.
+    generalized entropies. [Entropy, 20(11), 813.](https://www.mdpi.com/1099-4300/20/11/813)
 """
 abstract type Entropy <: AbstractEntropy end
 
@@ -57,19 +56,20 @@ abstract type EntropyEstimator <: AbstractEntropy end
 ###########################################################################################
 # Notice that StatsBase.jl exports `entropy` and Wavelets.jl exports `Entropy`.
 """
-    entropy([e::Entropy,] probs::Probabilities) → h::Real ∈ [0, ∞)
-    entropy([e::Entropy,] est::ProbabilitiesEstimator, x) → h::Real ∈ [0, ∞)
-    entropy([e::Entropy,] est::EntropyEstimator, x) → h::Real ∈ [0, ∞)
+    entropy([e::Entropy,] probs::Probabilities)
+    entropy([e::Entropy,] est::ProbabilitiesEstimator, x)
+    entropy([e::Entropy,] est::EntropyEstimator, x)
 
-Compute `h`, a (generalized) [`Entropy`](@ref) of type `e`, in one of three ways:
+Compute `h`, with `h::Real ∈ [0, ∞)`, which is
+a (generalized) [`Entropy`](@ref) of type `e`, in one of three ways:
 
 1. Directly from existing [`Probabilities`](@ref) `probs`.
 2. From input data `x`, by first estimating a probability distribution using the provided
-    [`ProbabilitiesEstimator`](@ref), then computing entropy from that distribution.
-    In fact, the second method is just a 2-lines-of-code wrapper that calls
-    [`probabilities`](@ref) and gives the result to the first method.
+   [`ProbabilitiesEstimator`](@ref), then computing entropy from that distribution.
+   In fact, the second method is just a 2-lines-of-code wrapper that calls
+   [`probabilities`](@ref) and gives the result to the first method.
 3. From input data `x`, by using a dedicated [`EntropyEstimator`](@ref) that computes
-    entropy in a way that doesn't involve explicitly computing probabilities first.
+   entropy in a way that doesn't involve explicitly computing probabilities first.
 
 The entropy (first argument) is optional. When `est` is a probability estimator,
 `Shannon()` is used by default. When `est` is a dedicated entropy estimator,
@@ -123,8 +123,9 @@ function entropy!(s::AbstractVector{Int}, e::Entropy, est::ProbabilitiesEstimato
     entropy(e, probs)
 end
 
-entropy!(s::AbstractVector{Int}, est::ProbabilitiesEstimator, x) =
+function entropy!(s::AbstractVector{Int}, est::ProbabilitiesEstimator, x)
     entropy!(s, Shannon(), est, x)
+end
 
 ###########################################################################################
 # API: entropy from entropy estimators
@@ -132,7 +133,7 @@ entropy!(s::AbstractVector{Int}, est::ProbabilitiesEstimator, x) =
 # Dispatch for these functions is implemented in individual estimator files in
 # `entropies/estimators/`.
 function entropy(e::Entropy, est::EntropyEstimator, x)
-    t = string(typeof(e).name.name)
+    t = string(nameof(typeof(e)))
     throw(ArgumentError("$t entropy not implemented for $(typeof(est)) estimator"))
 end
 

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -71,7 +71,8 @@ a (generalized) entropy defined by `e`, in one of three ways:
 3. From input data `x`, by using a dedicated [`EntropyEstimator`](@ref) that computes
    entropy in a way that doesn't involve explicitly computing probabilities first.
 
-The entropy (first argument) is optional. When `est` is a probability estimator,
+The entropy definition (first argument) is optional.
+When `est` is a probability estimator,
 `Shannon()` is used by default. When `est` is a dedicated entropy estimator,
 the default entropy type is inferred from the estimator (e.g. [`Kraskov`](@ref)
 estimates the [`Shannon`](@ref) entropy).

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -152,20 +152,16 @@ entropy(est::EntropyEstimator, x; base = 2) = entropy(Shannon(; base), est, x)
 # Normalize API
 ###########################################################################################
 """
-    entropy_maximum(e::Entropy, est::ProbabilitiesEstimator, x) → m::Real
+    entropy_maximum(e::Entropy, est::ProbabilitiesEstimator) → m::Real
 
-Return the maximum value `m` of the given entropy type based on the given estimator
-and the given input `x` (whose values are not important, but layout and type are).
-
-This function only works if the maximum value is deducable, which is possible only
-when the estimator has a known [`total_outcomes`](@ref).
+Return the maximum value `m` of the given entropy definition based on the given estimator.
 
     entropy_maximum(e::Entropy, L::Int) → m::Real
 
 Alternatively, compute the maximum entropy from the number of total outcomes `L` directly.
 """
-function entropy_maximum(e::Entropy, est::ProbabilitiesEstimator, x)
-    L = total_outcomes(x, est)
+function entropy_maximum(e::Entropy, est::ProbabilitiesEstimator)
+    L = total_outcomes(est)
     return entropy_maximum(e, L)
 end
 function entropy_maximum(e::Entropy, ::Int)
@@ -184,7 +180,7 @@ Notice that unlike for [`entropy`](@ref), here there is no method
 the amount of _possible_ events (i.e., the [`total_outcomes`](@ref)) from `probs`.
 """
 function entropy_normalized(e::Entropy, est::ProbabilitiesEstimator, x)
-    return entropy(e, est, x) / entropy_maximum(e, est, x)
+    return entropy(e, est, x) / entropy_maximum(e, est)
 end
 function entropy_normalized(est::ProbabilitiesEstimator, x::Array_or_Dataset)
     return entropy_normalized(Shannon(), est, x)

--- a/src/probabilities.jl
+++ b/src/probabilities.jl
@@ -67,6 +67,11 @@ across experimental realizations, by using the outcome as a dictionary key and t
 probability as the value for that key (or, alternatively, the key remains the outcome
 and one has a vector of probabilities, one for each experimental realization).
 
+We have made the design decision that all probabilities estimators have a well defined
+outcome space when instantiated. For some estimators this means that the input data
+`x` must be provided both when instantiating the estimator, but also when computing
+the probabilities.
+
 All currently implemented probability estimators are:
 
 - [`CountOccurrences`](@ref).

--- a/src/probabilities.jl
+++ b/src/probabilities.jl
@@ -33,11 +33,12 @@ function Probabilities(x::AbstractVector{<:Integer})
 end
 
 # extend base Vector interface:
-for f in (:length, :size, :eachindex, :eltype,
+for f in (:length, :size, :eachindex, :eltype, :parent,
     :lastindex, :firstindex, :vec, :getindex, :iterate)
     @eval Base.$(f)(d::Probabilities, args...) = $(f)(d.p, args...)
 end
 Base.IteratorSize(::Probabilities) = Base.HasLength()
+# Special extension due to the rules of the API
 @inline Base.sum(::Probabilities{T}) where T = one(T)
 
 """
@@ -139,11 +140,7 @@ function probabilities! end
 """
     outcome_space(est::ProbabilitiesEstimator) → Ω
 
-Return a container (typically `Vector`) containing all _possible_ outcomes of `est`,
-i.e., the outcome space `Ω`.
-Only possible for estimators that implement [`total_outcomes`](@ref),
-and similarly, for some estimators `x` is not needed. The _values_ of `x` are never needed;
-but some times the type and dimensional layout of `x` is.
+Return a container containing all _possible_ outcomes of `est`.
 """
 function outcome_space(est::ProbabilitiesEstimator)
     error("`outcome_space` not implemented for estimator $(typeof(est)).")
@@ -161,8 +158,6 @@ total_outcomes(est::ProbabilitiesEstimator) = length(outcome_space(est))
 
 Estimate a probability distribution for `x` using the given estimator, then count the number
 of missing (i.e. zero-probability) outcomes.
-
-Works for estimators that implement [`total_outcomes`](@ref).
 
 See also: [`MissingDispersionPatterns`](@ref).
 """

--- a/src/probabilities_estimators/counting/count_occurences.jl
+++ b/src/probabilities_estimators/counting/count_occurences.jl
@@ -1,7 +1,7 @@
 export CountOccurrences
 
 """
-    CountOccurrences()
+    CountOccurrences(x)
 
 A probabilities/entropy estimator based on straight-forward counting of distinct elements in
 a univariate time series or multivariate dataset. This is the same as giving no
@@ -9,8 +9,11 @@ estimator to [`probabilities`](@ref).
 
 ## Outcome space
 The outcome space is the unique sorted values of the input.
+Hence, input `x` is needed for a well-defined outcome space.
 """
-struct CountOccurrences <: ProbabilitiesEstimator end
+struct CountOccurrences{X} <: ProbabilitiesEstimator
+    x::X
+end
 
 function probabilities_and_outcomes(::CountOccurrences, x::Array_or_Dataset)
     z = copy(x)
@@ -19,7 +22,7 @@ function probabilities_and_outcomes(::CountOccurrences, x::Array_or_Dataset)
     return probs, unique!(z)
 end
 
-outcome_space(x, ::CountOccurrences) = sort!(unique(x))
+outcome_space(est::CountOccurrences) = sort!(unique(est.x))
 
 probabilities(::CountOccurrences, x::Array_or_Dataset) = probabilities(x)
 function probabilities(x::Array_or_Dataset)

--- a/src/probabilities_estimators/dispersion/dispersion.jl
+++ b/src/probabilities_estimators/dispersion/dispersion.jl
@@ -118,11 +118,11 @@ function probabilities_and_outcomes(est::Dispersion, x::AbstractVector{<:Real})
     return Probabilities(hist), dispersion_patterns
 end
 
-total_outcomes(est::Dispersion)::Int = est.encoding.c ^ est.m
-
 function outcome_space(est::Dispersion)
     c, m = 1:est.encoding.c, est.m
     cart = CartesianIndices(ntuple(i -> c, m))
     V = SVector{m, Int}
     return map(i -> V(Tuple(i)), vec(cart))
 end
+# Performance extension
+total_outcomes(est::Dispersion)::Int = total_outcomes(est.encoding) ^ est.m

--- a/src/probabilities_estimators/diversity/diversity.jl
+++ b/src/probabilities_estimators/diversity/diversity.jl
@@ -42,7 +42,8 @@ end
 
 function probabilities(est::Diversity, x::AbstractVector{T}) where T <: Real
     ds, rbc = similarities_and_binning(est, x)
-    return fasthist(rbc, ds)[1]
+    bins = fasthist(rbc, ds)[1]
+    return Probabilities(bins)
 end
 
 function probabilities_and_outcomes(est::Diversity, x::AbstractVector{T}) where T <: Real
@@ -69,4 +70,4 @@ end
 
 cosine_similarity(xᵢ, xⱼ) = sum(xᵢ .* xⱼ) / (sqrt(sum(xᵢ .^ 2)) * sqrt(sum(xⱼ .^ 2)))
 
-binning_for_diversity(est::Diversity) = FixedRectangularBinning((-1.0,), (1.0,), est.nbins)
+binning_for_diversity(est::Diversity) = FixedRectangularBinning(-1.0, 1.0, est.nbins)

--- a/src/probabilities_estimators/diversity/diversity.jl
+++ b/src/probabilities_estimators/diversity/diversity.jl
@@ -41,13 +41,13 @@ Base.@kwdef struct Diversity <: ProbabilitiesEstimator
 end
 
 function probabilities(est::Diversity, x::AbstractVector{T}) where T <: Real
-    ds, binning = similarities_and_binning(est, x)
-    return fasthist(ds, binning)[1]
+    ds, rbc = similarities_and_binning(est, x)
+    return fasthist(rbc, ds)[1]
 end
 
 function probabilities_and_outcomes(est::Diversity, x::AbstractVector{T}) where T <: Real
-    ds, binning = similarities_and_binning(est, x)
-    return probabilities_and_outcomes(ValueHistogram(binning), ds)
+    ds, rbc = similarities_and_binning(est, x)
+    return probabilities_and_outcomes(ValueHistogram(rbc), ds)
 end
 
 outcome_space(est::Diversity) = outcome_space(binning_for_diversity(est))
@@ -63,9 +63,10 @@ function similarities_and_binning(est::Diversity, x::AbstractVector{T}) where T 
     end
     # Cosine similarities are all on [-1.0, 1.0], so just discretize this interval.
     binning = binning_for_diversity(est)
-    return ds, binning
+    rbc = RectangularBinEncoding(binning)
+    return ds, rbc
 end
 
 cosine_similarity(xᵢ, xⱼ) = sum(xᵢ .* xⱼ) / (sqrt(sum(xᵢ .^ 2)) * sqrt(sum(xⱼ .^ 2)))
 
-binning_for_diversity(est::Diversity) = FixedRectangularBinning(-1.0, 1.0, est.nbins)
+binning_for_diversity(est::Diversity) = FixedRectangularBinning((-1.0,), (1.0,), est.nbins)

--- a/src/probabilities_estimators/diversity/diversity.jl
+++ b/src/probabilities_estimators/diversity/diversity.jl
@@ -7,7 +7,7 @@ export Diversity
 
 A [`ProbabilitiesEstimator`](@ref) based on the cosine similarity.
 It can be used with [`entropy`](@ref) to
-compute diversity entropy (Wang et al., 2020)[^Wang2020].
+compute the diversity entropy of an input timeseries[^Wang2020].
 
 The implementation here allows for `τ != 1`, which was not considered in the original paper.
 
@@ -26,12 +26,8 @@ Diversity probabilities are computed as follows.
 5. Sum-normalize the histogram to obtain probabilities.
 
 ## Outcome space
-The outcome space for `Diversity` is the bins of the `[-1, 1]` interval.
-The left side of each bin is returned in [`outcome_space`](@ref).
-
-- [`probabilities_and_outcomes`](@ref). Events are the corners of the cosine similarity bins.
-    Each bin has width `nextfloat(2 / nbins)`.
-- [`total_outcomes`](@ref). The total number of states is given by `nbins`.
+The outcome space for `Diversity` is the bins of the `[-1, 1]` interval,
+and the return configuration is the same as in [`ValueHistogram`](@ref) (left bin edge).
 
 [^Wang2020]:
     Wang, X., Si, S., & Li, Y. (2020). Multiscale diversity entropy: A novel
@@ -54,9 +50,8 @@ function probabilities_and_outcomes(est::Diversity, x::AbstractVector{T}) where 
     return probabilities_and_outcomes(ValueHistogram(binning), ds)
 end
 
+outcome_space(est::Diversity) = outcome_space(binning_for_diversity(est))
 total_outcomes(est::Diversity) = est.nbins
-
-outcome_space(x, est::Diversity) = outcome_space(x, binning_for_diversity(est))
 
 function similarities_and_binning(est::Diversity, x::AbstractVector{T}) where T <: Real
     # embed and then calculate cosine similary for each consecutive pair of delay vectors

--- a/src/probabilities_estimators/histograms/rectangular_binning.jl
+++ b/src/probabilities_estimators/histograms/rectangular_binning.jl
@@ -7,7 +7,7 @@ abstract type HistogramEncoding <: Encoding end
 ##################################################################
 # Structs and docstrings
 ##################################################################
-# Notice that the binning types are intermediate structs that are NOT retained
+# Notice that the binning types are intermediate structs that are not used directly
 # in the source code. Their only purpose is instructions of how to create a
 # `RectangularBinEncoder`. All actual source code functionality of `ValueHistogram`
 # is implemented based on `RectangularBinEncoder`.
@@ -39,43 +39,34 @@ const ValidFixedBinInputs = Union{Number, NTuple}
 
 """
     FixedRectangularBinning <: AbstractBinning
-    FixedRectangularBinning(ϵmin::E, ϵmax::E, N::Int) where E
+    FixedRectangularBinning(ϵmin::NTuple, ϵmax::NTuple, N::Int)
 
 Rectangular box partition of state space where the extent of the grid is explicitly
 specified by `ϵmin` and `emax`, and along each dimension, the grid is subdivided into `N`
 subintervals. Points falling outside the partition do not attribute to probabilities.
+This binning type leads to a well-defined outcome space without knowledge of input,
+see [`ValueHistogram`](@ref).
 
-Binning instructions are deduced from the types of `ϵmin`/`emax` as follows:
+`ϵmin`/`emax` must be `NTuple{D, <:Real}` for input of `D`-dimensional data.
 
-1. `E<:Real` sets the grid range along all dimensions to to `[ϵmin, ϵmax]`.
-2. `E::NTuple{D, <:Real}` sets ranges along each dimension individually, i.e.
-    `[ϵmin[i], ϵmax[i]]` is the range along the `i`-th dimension.
+    FixedRectangularBinning(ϵmin::Real, ϵmax::Real, N::Int, D::Int = 1)
 
-If the grid spans the range `[r1, r2]` along a particular dimension, then this range
-is subdivided into `N` subintervals of equal length `nextfloat((r2 - r1)/N)`.
-Thus, for `D`-dimensional data, there are `N^D` boxes.
-
-Generally it is preferred to use the second method (`E::NTuple{D, <:Real}`) which
-has a well defined outcome space irrespectively of input data.
+This is a convenience method where each dimension of the binning has the same extent
+and the input data are `D` dimensional, which defaults to 1 (timeseries).
 """
-struct FixedRectangularBinning{E} <: AbstractBinning
-    ϵmin::E
-    ϵmax::E
+struct FixedRectangularBinning{D,T<:Real} <: AbstractBinning
+    ϵmin::NTuple{D,T}
+    ϵmax::NTuple{D,T}
     N::Int
-
-    function FixedRectangularBinning(ϵmin::E1, ϵmax::E2, N::Int) where {E1 <: ValidFixedBinInputs, E2 <: ValidFixedBinInputs}
-        f_ϵmin = float.(ϵmin)
-        f_ϵmax = float.(ϵmax)
-        return new{typeof(f_ϵmin)}(f_ϵmin, f_ϵmax, N)
-    end
 end
-
-const Floating_or_Fixed_RectBinning = Union{RectangularBinning, FixedRectangularBinning}
+function FixedRectangularBinning(ϵmin::Real, ϵmax::Real, N::Int, D::Int = 1)
+    FixedRectangularBinning(ntuple(x->ϵmin, D), ntuple(x->ϵmax, D), N)
+end
 
 """
     RectangularBinEncoding <: Encoding
-    RectangularBinEncoding(x, binning::AbstractBinning)
-    RectangularBinEncoding(binning::FixedRectangularBinning{<:NTuple{D}})
+    RectangularBinEncoding(binning::RectangularBinning, x)
+    RectangularBinEncoding(binning::FixedRectangularBinning)
 
 Struct used in [`outcomes`](@ref) to map points of `x` into their respective bins.
 It finds the minima along each dimension, and computes appropriate
@@ -134,8 +125,9 @@ end
 ##################################################################
 # Initialization of encodings
 ##################################################################
+# TODO: Document `n_eps`
 # Data-controlled grid
-function RectangularBinEncoding(x, b::RectangularBinning; n_eps = 2)
+function RectangularBinEncoding(b::RectangularBinning, x; n_eps = 2)
     # This function always returns static vectors and is type stable
     D = dimension(x)
     T = eltype(x)
@@ -166,33 +158,17 @@ function RectangularBinEncoding(x, b::RectangularBinning; n_eps = 2)
 end
 
 # fixed grid
-function RectangularBinEncoding(x, b::FixedRectangularBinning{E}; n_eps = 2) where {E}
-    D = dimension(x)
-    T = eltype(x)
-    D ≠ length(E) && error("Dimension of data and fixed rectangular binning don't match!")
+function RectangularBinEncoding(b::FixedRectangularBinning{D,T}; n_eps = 2) where {D,T}
     # This function always returns static vectors and is type stable
     ϵmin, ϵmax = b.ϵmin, b.ϵmax
-    if E <: Real
-        mini = SVector{D, T}(repeat([ϵmin], D))
-        maxi = SVector{D, T}(repeat([ϵmax], D))
-    elseif E <: NTuple{D}
-        mini = SVector{D, T}(ϵmin)
-        maxi = SVector{D, T}(ϵmax)
-    else
-        error("Invalid ϵmin or ϵmax for binning of a dataset")
-    end
+    mini = SVector{D, T}(ϵmin)
+    maxi = SVector{D, T}(ϵmax)
     edgelengths_nonadjusted = @. (maxi .- mini) / b.N
     edgelengths = nextfloat.(edgelengths_nonadjusted, n_eps)
     histsize = SVector{D,Int}(fill(b.N, D))
     ci = CartesianIndices(Tuple(histsize))
     li = LinearIndices(ci)
     RectangularBinEncoding(b, mini, edgelengths, histsize, ci, li)
-end
-
-# This version exists if the given `ϵ`s are already tuples.
-# Then, the dataset doesn't need to be provided.
-function RectangularBinEncoding(b::FixedRectangularBinning{<:NTuple{D,T}}; n_eps = 2) where {D,T}
-    return RectangularBinEncoding(Dataset{D,T}(), b; n_eps)
 end
 
 ##################################################################

--- a/src/probabilities_estimators/histograms/rectangular_binning.jl
+++ b/src/probabilities_estimators/histograms/rectangular_binning.jl
@@ -210,12 +210,12 @@ end
 ##################################################################
 # This method is called by `probabilities(est::ValueHistogram, x::Array_or_Dataset)`
 """
-    fasthist(x::Vector_or_Dataset, ϵ::RectangularBinEncoding)
+    fasthist(c::RectangularBinEncoding, x::Vector_or_Dataset)
 Intermediate method that runs `fasthist!` in the encoded space
 and returns the encoded space histogram (counts) and corresponding bins.
 Also skips any instances of out-of-bound points for the histogram.
 """
-function fasthist(x, encoder::RectangularBinEncoding)
+function fasthist(encoder::RectangularBinEncoding, x)
     bins = map(y -> encode(y, encoder), x)
     # We discard `-1`, as it encodes points outside the histogram limit
     # (which should only happen for `Fixed` binnings)

--- a/src/probabilities_estimators/histograms/rectangular_binning.jl
+++ b/src/probabilities_estimators/histograms/rectangular_binning.jl
@@ -158,7 +158,7 @@ function RectangularBinEncoding(b::RectangularBinning, x; n_eps = 2)
 end
 
 # fixed grid
-function RectangularBinEncoding(b::FixedRectangularBinning{D,T}; n_eps = 2) where {D,T}
+function RectangularBinEncoding(b::FixedRectangularBinning{D, T}; n_eps = 2) where {D,T}
     # This function always returns static vectors and is type stable
     ϵmin, ϵmax = b.ϵmin, b.ϵmax
     mini = SVector{D, T}(ϵmin)
@@ -168,7 +168,7 @@ function RectangularBinEncoding(b::FixedRectangularBinning{D,T}; n_eps = 2) wher
     histsize = SVector{D,Int}(fill(b.N, D))
     ci = CartesianIndices(Tuple(histsize))
     li = LinearIndices(ci)
-    RectangularBinEncoding(b, mini, edgelengths, histsize, ci, li)
+    RectangularBinEncoding(b, typeof(edgelengths)(mini), edgelengths, histsize, ci, li)
 end
 
 ##################################################################

--- a/src/probabilities_estimators/histograms/rectangular_binning.jl
+++ b/src/probabilities_estimators/histograms/rectangular_binning.jl
@@ -95,7 +95,7 @@ function Base.show(io::IO, x::RectangularBinEncoding)
     )
 end
 
-function encode(point, e::RectangularBinEncoding)
+function encode(e::RectangularBinEncoding, point)
     (; mini, edgelengths) = e
     # Map a data point to its bin edge (plus one because indexing starts from 1)
     bin = floor.(Int, (point .- mini) ./ edgelengths) .+ 1
@@ -110,7 +110,7 @@ function encode(point, e::RectangularBinEncoding)
     end
 end
 
-function decode(bin::Int, e::RectangularBinEncoding{B, D, T}) where {B, D, T}
+function decode(e::RectangularBinEncoding{B, D, T}, bin::Int) where {B, D, T}
     V = SVector{D,T}
     if checkbounds(Bool, e.ci, bin)
         @inbounds cartesian = e.ci[bin]
@@ -178,7 +178,7 @@ total_outcomes(e::RectangularBinEncoding) = prod(e.histsize)
 
 function outcome_space(e::RectangularBinEncoding)
     # this is super simple :P could be optimized but its not a frequent operation
-    return [decode(i, e) for i in 1:total_outcomes(e)]
+    return [decode(e, i) for i in 1:total_outcomes(e)]
 end
 
 ##################################################################
@@ -192,7 +192,7 @@ and returns the encoded space histogram (counts) and corresponding bins.
 Also skips any instances of out-of-bound points for the histogram.
 """
 function fasthist(encoder::RectangularBinEncoding, x)
-    bins = map(y -> encode(y, encoder), x)
+    bins = map(y -> encode(encoder, y), x)
     # We discard `-1`, as it encodes points outside the histogram limit
     # (which should only happen for `Fixed` binnings)
     discard_minus_ones!(bins)

--- a/src/probabilities_estimators/histograms/value_histogram.jl
+++ b/src/probabilities_estimators/histograms/value_histogram.jl
@@ -4,7 +4,7 @@ include("rectangular_binning.jl")
 include("fasthist.jl")
 
 """
-    ValueHistogram(x, b::AbstractBinning) <: ProbabilitiesEstimator
+    ValueHistogram(x, b::RectangularBinning) <: ProbabilitiesEstimator
     ValueHistogram(b::FixedRectangularBinning) <: ProbabilitiesEstimator
 
 A probability estimator based on binning the values of the data as dictated by
@@ -42,8 +42,8 @@ struct ValueHistogram{H<:HistogramEncoding} <: ProbabilitiesEstimator
     encoding::H
 end
 ValueHistogram(x, ϵ::Union{Real,Vector}) = ValueHistogram(x, RectangularBinning(ϵ))
-function ValueHistogram(x, b::AbstractBinning)
-    encoding = RectangularBinEncoding(x, b)
+function ValueHistogram(x, b::RectangularBinning)
+    encoding = RectangularBinEncoding(b, x)
     return ValueHistogram(encoding)
 end
 function ValueHistogram(b::FixedRectangularBinning)

--- a/src/probabilities_estimators/histograms/value_histogram.jl
+++ b/src/probabilities_estimators/histograms/value_histogram.jl
@@ -41,7 +41,7 @@ See also: [`RectangularBinning`](@ref).
 struct ValueHistogram{H<:HistogramEncoding} <: ProbabilitiesEstimator
     encoding::H
 end
-ValueHistogram(ϵ::Union{Real,Vector}) = ValueHistogram(RectangularBinning(ϵ))
+ValueHistogram(x, ϵ::Union{Real,Vector}) = ValueHistogram(x, RectangularBinning(ϵ))
 function ValueHistogram(x, b::AbstractBinning)
     encoding = RectangularBinEncoding(x, b)
     return ValueHistogram(encoding)
@@ -63,7 +63,7 @@ const VisitationFrequency = ValueHistogram
 # the underlying encoding and the `fasthist` function and extensions.
 # See the `rectangular_binning.jl` file for more.
 function probabilities(est::ValueHistogram, x)
-    Probabilities(fasthist(x, est.encoding)[1])
+    Probabilities(fasthist(est.encoding, x)[1])
 end
 
 function probabilities_and_outcomes(est::ValueHistogram, x)
@@ -74,5 +74,4 @@ function probabilities_and_outcomes(est::ValueHistogram, x)
     return Probabilities(probs), vec(outcomes)
 end
 
-outcome_space(x, est::ValueHistogram) = outcome_space(est.encoding)
-total_outcomes(x, est::ValueHistogram) = total_outcomes(est.encoding)
+outcome_space(est::ValueHistogram) = outcome_space(est.encoding)

--- a/src/probabilities_estimators/histograms/value_histogram.jl
+++ b/src/probabilities_estimators/histograms/value_histogram.jl
@@ -67,7 +67,7 @@ function probabilities(est::ValueHistogram, x)
 end
 
 function probabilities_and_outcomes(est::ValueHistogram, x)
-    probs, bins = fasthist(x, est.encoding) # bins are integers here
+    probs, bins = fasthist(est.encoding, x) # bins are integers here
     unique!(bins) # `bins` is already sorted from `fasthist!`
     # Here we transfor the cartesian coordinate based bins into data unit bins:
     outcomes = map(b -> decode(b, est.encoding), bins)

--- a/test/convenience.jl
+++ b/test/convenience.jl
@@ -1,17 +1,16 @@
 using Entropies
 using Test
-import Statistics
 
 @testset "Common literature names" begin
     x = randn(1000)
-    σ = 0.2*Statistics.std(x)
+    σ = 0.2
 
     @testset "Permutation entropy" begin
         @test entropy_permutation(x) == entropy(SymbolicPermutation(), x)
     end
 
     @testset "Wavelet entropy" begin
-        @test entropy_wavelet(x) == entropy(WaveletOverlap(), x)
+        @test entropy_wavelet(x) == entropy(WaveletOverlap(x), x)
     end
 
     @testset "Dispersion entropy" begin

--- a/test/convenience.jl
+++ b/test/convenience.jl
@@ -26,7 +26,7 @@ import Statistics
     end
 end
 
-@testset "`probabilities` defaults to `CountOccurrences`" begin
+@testset "probabilities(x)" begin
     x = [1, 1, 2, 2, 3, 3]
-    @test probabilities(x) == probabilities(CountOccurrences(), x) == [1/3, 1/3, 1/3]
+    @test probabilities(x) == probabilities(CountOccurrences(x), x) == [1/3, 1/3, 1/3]
 end

--- a/test/probabilities/estimators/count_occurrences.jl
+++ b/test/probabilities/estimators/count_occurrences.jl
@@ -6,23 +6,23 @@ rng = Random.MersenneTwister(1234)
 x = [rand(rng, Bool) for _ in 1:10000]
 
 probs1 = probabilities(x)
-probs2 = probabilities(CountOccurrences(), x)
-probs3, outs = probabilities_and_outcomes(CountOccurrences(), x)
+probs2 = probabilities(CountOccurrences(x), x)
+probs3, outs = probabilities_and_outcomes(CountOccurrences(x), x)
 
 for ps in (probs1, probs2, probs3)
     for p in ps; @test 0.49 < p < 0.51; end
 end
 
-@test outs == [false, true]
-@test outcome_space(x, CountOccurrences()) == [false, true]
-@test total_outcomes(x, CountOccurrences()) == 2
+@test sort(outs) == [false, true]
+@test sort(outcome_space(CountOccurrences(x))) == [false, true]
+@test total_outcomes(CountOccurrences(x)) == 2
 
 # Same for 2D sets (outcomes not tested here)
 y = [rand(rng, Bool) for _ in 1:10000]
 D = Dataset(x, y)
 
 probs1 = probabilities(D)
-probs2 = probabilities(CountOccurrences(), D)
+probs2 = probabilities(CountOccurrences(D), D)
 for ps in (probs1, probs2)
     for p in ps; @test 0.24 < p < 0.26; end
 end
@@ -30,8 +30,8 @@ end
 # Renyi of coin toss is 1 bit, and for two coin tosses is two bits
 # Result doesn't depend on `q` due to uniformity of the PDF.
 for q in (0.5, 1.0, 2.0)
-    h = entropy(Renyi(q), CountOccurrences(), x)
+    h = entropy(Renyi(q), CountOccurrences(x), x)
     @test 0.99 < h < 1.01
-    h = entropy(Renyi(q), CountOccurrences(), D)
+    h = entropy(Renyi(q), CountOccurrences(D), D)
     @test 1.99 < h < 2.01
 end

--- a/test/probabilities/estimators/dispersion.jl
+++ b/test/probabilities/estimators/dispersion.jl
@@ -1,4 +1,6 @@
-using Entropies, Test
+using Entropies
+using Test
+import DelayEmbeddings
 
 @testset "Dispersion" begin
 
@@ -12,7 +14,7 @@ using Entropies, Test
         s = GaussianCDFEncoding(c)
 
         # Symbols should be in the set [1, 2, …, c].
-        symbols = Entropies.outcomes(x, s)
+        symbols = outcomes(x, s)
         @test all([s ∈ collect(1:c) for s in symbols])
 
         # Dispersion patterns should have a normalized histogram that sums to 1.0.

--- a/test/probabilities/estimators/diversity.jl
+++ b/test/probabilities/estimators/diversity.jl
@@ -1,3 +1,5 @@
+using Entropies, Test
+
 # Analytical example from Wang et al. (2020)
 x = [1, 2, 13, 7, 9, 5, 4]
 nbins = 10
@@ -22,5 +24,5 @@ bins = floor.(Int, (ds .- (-1.0)) / binsize)
 
 # The coordinates corresponding to the left corners of these bins are as
 # follows, and should correspond with the events.
-coords = ((bins .- 1) .* binsize) .+ (-1.0)
-@test all(round.(events, digits = 13) == round.(unique(coords), digits = 13))
+coords = (bins .* binsize) .+ (-1.0)
+@test all(round.(only.(events), digits = 13) == round.(unique(coords), digits = 13))

--- a/test/probabilities/estimators/timescales.jl
+++ b/test/probabilities/estimators/timescales.jl
@@ -21,14 +21,14 @@ using Entropies, Test
         x = sin.(t)
         y = @. sin(t) + sin(sqrt(3)*t)
         z = randn(N)
-        est = PowerSpectrum()
+        est = PowerSpectrum(N)
         ents = [entropy(Renyi(), est, w) for w in (x,y,z)]
         @test ents[1] < ents[2] < ents[3]
         # Test event stuff (analytically, using sine wave)
-        probs, events = probabilities_and_outcomes(est, x)
-        @test length(events) == length(probs) == 501
-        @test events[1] ≈ 0 atol=1e-16 # 0 frequency, i.e., mean value
+        probs, outs = probabilities_and_outcomes(est, x)
+        @test length(outs) == length(probs) == 501
+        @test outs[1] ≈ 0 atol=1e-16 # 0 frequency, i.e., mean value
         @test probs[1] ≈ 0 atol=1e-16  # sine wave has 0 mean value
-        @test events[end] == 0.5 # Nyquist frequency, 1/2 the sampling rate (Which is 1)
+        @test outs[end] == 0.5 # Nyquist frequency, 1/2 the sampling rate (Which is 1)
     end
 end

--- a/test/probabilities/estimators/timescales.jl
+++ b/test/probabilities/estimators/timescales.jl
@@ -7,12 +7,12 @@ using Entropies, Test
     x = sin.(t .+  cos.(t/0.1)) .- 0.1;
 
     @testset "WaveletOverlap" begin
-        wl = Entropies.Wavelets.WT.Daubechies{4}()
+        wl = Entropies.Wavelets.WT.Daubechies{4}(x)
         est = WaveletOverlap(wl)
         ps = probabilities(est, x)
         @test length(ps) == 8
         @test ps isa Probabilities
-        @test entropy(Renyi( q = 1, base = 2), WaveletOverlap(), x) isa Real
+        @test entropy(Renyi( q = 1, base = 2), WaveletOverlap(x), x) isa Real
     end
 
     @testset "Fourier Spectrum" begin

--- a/test/probabilities/estimators/timescales.jl
+++ b/test/probabilities/estimators/timescales.jl
@@ -7,8 +7,8 @@ using Entropies, Test
     x = sin.(t .+  cos.(t/0.1)) .- 0.1;
 
     @testset "WaveletOverlap" begin
-        wl = Entropies.Wavelets.WT.Daubechies{4}(x)
-        est = WaveletOverlap(wl)
+        wl = Entropies.Wavelets.WT.Daubechies{4}()
+        est = WaveletOverlap(x, wl)
         ps = probabilities(est, x)
         @test length(ps) == 8
         @test ps isa Probabilities

--- a/test/probabilities/estimators/value_histogram.jl
+++ b/test/probabilities/estimators/value_histogram.jl
@@ -30,7 +30,7 @@ using Random
             @test o isa Vector{SVector{2, Float64}}
             @test length(o) == length(p)
             @test all(x -> x < 1, maximum(o))
-            o2 = outcomes(x, est)
+            o2 = outcomes(est, x)
             @test o2 == o
         end
     end

--- a/test/probabilities/interface.jl
+++ b/test/probabilities/interface.jl
@@ -1,3 +1,3 @@
 x = ones(3)
-p = probabilities(ValueHistogram(0.1), x)
+p = probabilities(x)
 @test p isa Probabilities


### PR DESCRIPTION
Closes #185, closes #184

Implements the final version of the API which is:
- algorithm deciding arguments first, input data after.
- Also applies for `encode/decode`.
- Use funtions not functors

Also re-writes `FixedRectangularBinning` to have welldefined outcome space always.