### PR TITLE
Fix conflicting import for `entropy`

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -72,7 +72,7 @@ nats for this distribution is `ln(1 - 0) = 0`.
 ```@example MAIN
 using Entropies
 using Statistics
-using Distributions
+using Distributions: Uniform
 using CairoMakie
 
 # Define estimators


### PR DESCRIPTION
Many of the documentation examples won't build due to conflicting imports between `Entropies.entropy` and `Distributions.entropy`. This PR fixes that by explicitly importing only necessary types from Distributions.jl.