### PR TITLE
Adjust `GaussianCDFEncoding` and related stuff for new encoding API

### DIFF
--- a/src/complexity/missing_patterns/missing_dispersion.jl
+++ b/src/complexity/missing_patterns/missing_dispersion.jl
@@ -33,6 +33,11 @@ computed. The authors recommend that
 `total_outcomes(est.symbolization)^est.m << length(x) - est.m*est.τ + 1` to avoid
 undersampling.
 
+!!! note "Encoding"
+    [`Dispersion`](@ref)'s linear mapping from CDFs to integers is based on equidistant
+    partitioning of the interval `[0, 1]`. This is slightly different from Zhou et
+    al. (2022), which uses the linear mapping ``s_i := \\text{round}(y + 0.5)``.
+
 ## Usage
 
 In Zhou et al. (2022), [`MissingDispersionPatterns`](@ref) is used to detect nonlinearity

--- a/src/complexity/reverse_dispersion_entropy/reverse_dispersion_entropy.jl
+++ b/src/complexity/reverse_dispersion_entropy/reverse_dispersion_entropy.jl
@@ -6,8 +6,7 @@ export distance_to_whitenoise
 
 """
     ReverseDispersion <: ComplexityMeasure
-    ReverseDispersion(; m = 2, τ = 1, check_unique = true,
-        encoding::Encoding = GaussianCDFEncoding(c = 5)
+    ReverseDispersion(; c = 3, m = 2, τ = 1, check_unique = true,
     )
 
 Estimator for the reverse dispersion entropy complexity measure (Li et al., 2019)[^Li2019].
@@ -48,19 +47,15 @@ unique element, then a `InexactError` is thrown when trying to compute probabili
 [^Li2019]: Li, Y., Gao, X., & Wang, L. (2019). Reverse dispersion entropy: a new
     complexity measure for sensor signal. Sensors, 19(23), 5203.
 """
-struct ReverseDispersion{S <: Encoding} <: ComplexityMeasure
-    encoding::S
-    m::Int
-    τ::Int
-    check_unique::Bool
-
-    function ReverseDispersion(; c = 5, m = 2, τ = 1, check_unique::Bool = false)
-        encoding = GaussianCDFEncoding(; c)
-        new{typeof(encoding)}(encoding, m, τ, check_unique)
-    end
+Base.@kwdef struct ReverseDispersion{S <: Encoding} <: ComplexityMeasure
+    encoding::Type{S} = GaussianCDFEncoding # any encoding at accepts keyword `c`
+    c::Int = 3 # The number of categories to map encoded values to.
+    m::Int = 2
+    τ::Int = 1
+    check_unique::Bool = false
 end
 
-total_outcomes(est::ReverseDispersion)::Int = total_outcomes(est.encoding) ^ est.m
+total_outcomes(est::ReverseDispersion)::Int = est.c ^ est.m
 
 """
     distance_to_whitenoise(estimator::ReverseDispersion, p::Probabilities;
@@ -91,13 +86,13 @@ function distance_to_whitenoise(est::ReverseDispersion, p::Probabilities; normal
 end
 
 function complexity(measure::ReverseDispersion, x)
-    (; encoding, m, τ, check_unique) = measure
-    p = probabilities(Dispersion(; c = encoding.c, m, τ, check_unique), x)
+    (; encoding, c, m, τ, check_unique) = measure
+    p = probabilities(Dispersion(; c, m, τ, check_unique), x)
     return distance_to_whitenoise(measure, p, normalize = false)
 end
 
 function complexity_normalized(measure::ReverseDispersion, x)
-    (; encoding, m, τ, check_unique) = measure
-    p = probabilities(Dispersion(; c = encoding.c, m, τ, check_unique), x)
+    (; encoding, c, m, τ, check_unique) = measure
+    p = probabilities(Dispersion(; c, m, τ, check_unique), x)
     return distance_to_whitenoise(measure, p, normalize = true)
 end

--- a/src/encoding/gaussian_cdf.jl
+++ b/src/encoding/gaussian_cdf.jl
@@ -4,41 +4,48 @@ export GaussianCDFEncoding
 
 """
     GaussianCDFEncoding <: Encoding
-    GaussianCDFEncoding(c::Int = 3)
+    GaussianCDFEncoding(; μ, σ, c::Int = 3)
 
-A encoding scheme where the elements of `x` are discretized into `c` distinct integer
-categories using the normal cumulative distribution function (NCDF), used with
-[`outcomes`](@ref).
+An encoding scheme that [`encode`](@ref)s a scalar value into one of the integers
+`sᵢ ∈ [1, 2, …, c]` based on the normal cumulative distribution function (NCDF),
+and [`decode`](@ref)s the `sᵢ` into subintervals of `[0, 1]` (with some loss of information).
 
 ## Algorithm
 
-Assume we have a univariate time series ``X = \\{x_i\\}_{i=1}^N``. `GaussianCDFEncoding`
-first maps each ``x_i`` to a new real number ``y_i \\in [0, 1]`` by using the normal
-cumulative distribution function (CDF), ``x_i \\to y_i : y_i = \\dfrac{1}{ \\sigma
-    \\sqrt{2 \\pi}} \\int_{-\\infty}^{x_i} e^{(-(x_i - \\mu)^2)/(2 \\sigma^2)} dx``,
-where ``\\mu`` and ``\\sigma`` are the empirical mean and standard deviation of ``X``.
+`GaussianCDFEncoding` first maps an input point ``x``  (scalar) to a new real number
+``y_ \\in [0, 1]`` by using the normal cumulative distribution function (CDF) with the
+given mean `μ` and standard deviation `σ`, according to the map
 
-Next, each ``y_i`` is linearly mapped to an integer
-``z_i \\in [1, 2, \\ldots, c]`` using the map
-``y_i \\to z_i : z_i = R(y_i(c-1) + 0.5)``, where ``R`` indicates rounding up to the
-nearest integer. This procedure subdivides the interval ``[0, 1]`` into ``c``
-different subintervals that form a covering of ``[0, 1]``, and assigns each ``y_i`` to one
-of these subintervals. The original time series ``X`` is thus transformed to a symbol time
+```math
+x \\to y : y = \\dfrac{1}{ \\sigma
+    \\sqrt{2 \\pi}} \\int_{-\\infty}^{x} e^{(-(x - \\mu)^2)/(2 \\sigma^2)} dx.
+```
+
+Next, the interval `[0, 1]` is equidistantly binned and enumerated ``1, 2, \\ldots, c``.
+ and ``y`` is linearly mapped to one of these integers using the linear map
+ ``y \\to z : z = \\text{floor}(y(c-1)) + 1``.
+
+Because of the ceiling operation, some information is lost, so when used with
+[`decode`](@ref), each decoded `sᵢ` is mapped to a *subinterval* of `[0, 1]`.
+
+## Usage
+
+In the implementations of [`Dispersion`](@ref) and [`RelativeDispersion`](@ref),
+we use the empirical means `μ` and standard deviation `σ`, as determined from
+a univariate input timeseries ``X = \\{x_i\\}_{i=1}^N``, and after encoding, the input
+is thus transformed to a symbol time
 series ``S = \\{ s_i \\}_{i=1}^N``, where ``s_i \\in [1, 2, \\ldots, c]``.
-
-# Usage
-
-    outcomes(x::AbstractVector, s::GaussianCDFEncoding)
-
-Map the elements of `x` to a symbol time series according to the Gaussian encoding
-scheme `s`.
 
 ## Examples
 
-```jldoctest; setup = :(using Entropies)
+```jldoctest
+julia> using Entropies, Statistics
+
 julia> x = [0.1, 0.4, 0.7, -2.1, 8.0, 0.9, -5.2];
 
-julia> Entropies.outcomes(x, GaussianCDFEncoding(5))
+julia> μ, σ = mean(x), std(x); encoding = GaussianCDFEncoding(; μ, σ, c = 5)
+
+julia> es = Entropies.encode.(Ref(encoding), x)
 7-element Vector{Int64}:
  3
  3
@@ -47,36 +54,37 @@ julia> Entropies.outcomes(x, GaussianCDFEncoding(5))
  5
  3
  1
-```
 
-See also: [`outcomes`](@ref).
+julia ds = Entropies.decode.(Ref(encoding), es)
+```
 """
-Base.@kwdef struct GaussianCDFEncoding <: Encoding
-    c::Int = 3
+struct GaussianCDFEncoding{T} <: Encoding
+    c::Int
+    σ::T
+    μ::T
+    # We require the input data, because we need σ and μ for encoding single values.
+    function GaussianCDFEncoding(; μ::T, σ::T, c::Int = 3) where T
+        new{T}(c, σ, μ)
+    end
 end
 
 total_outcomes(encoding::GaussianCDFEncoding) = encoding.c
 
 g(xᵢ, μ, σ) = exp((-(xᵢ - μ)^2)/(2σ^2))
 
-"""
-    map_to_category(yⱼ, c)
-
-Map the value `yⱼ ∈ (0, 1)` to an integer `[1, 2, …, c]`.
-"""
-function map_to_category(yⱼ, c)
-    zⱼ = ceil(Int, yⱼ * (c - 1) + 1/2)
-    return zⱼ
-end
-
-function outcomes(x::AbstractVector, s::GaussianCDFEncoding)
-    σ = Statistics.std(x)
-    μ = Statistics.mean(x)
-
+function encode(encoding::GaussianCDFEncoding, x)
+    (; c, σ, μ) = encoding
     # We only need the value of the integral (not the error), so
     # index first element returned from quadgk
     k = 1/(σ*sqrt(2π))
-    yⱼs = [k * first(quadgk(x -> g(x, μ, σ), -Inf, xᵢ)) for xᵢ in x]
+    y = k * first(quadgk(xᵢ -> g(xᵢ, μ, σ), -Inf, x))
+    return floor.(Int, y ./ (1 / c)) + 1
+end
 
-    return map_to_category.(yⱼs, s.c)
+function decode(encoding::GaussianCDFEncoding, i::Int)
+    c = encoding.c
+    V = SVector{2, eltype(1.0)}
+    lower_interval_bound = (i - 1)/(c)
+
+    yⱼ = V(lower_interval_bound, lower_interval_bound + 1/c - eps())
 end

--- a/src/encodings.jl
+++ b/src/encodings.jl
@@ -20,7 +20,9 @@ abstract type Encoding end
     encode(c::Encoding, χ) -> i::Int
 
 Encode an element `χ ∈ x` of input data `x` (those given to [`probabilities`](@ref))
-using encoding `c`. The special value of `-1` is reserved as a return value for
+using encoding `c`.
+
+The special value of `-1` is reserved as a return value for
 inappropriate elements `χ` that cannot be encoded according to `c`.
 """
 function encode end
@@ -29,6 +31,7 @@ function encode end
     decode(c::Encoding, i::Int) -> ω
 
 Decode an encoded element `i` into the outcome `ω ∈ Ω` it corresponds to.
+
 `Ω` is the [`outcome_space`](@ref) of a probabilities estimator that uses encoding `c`.
 """
 function decode end

--- a/src/probabilities_estimators/kernel/kernel_density.jl
+++ b/src/probabilities_estimators/kernel/kernel_density.jl
@@ -3,7 +3,7 @@ using Distances: Metric, Euclidean
 export NaiveKernel, KDTree, BruteForce
 
 """
-    NaiveKernel(x, ϵ::Real; ss = KDTree, w = 0, metric = Euclidean()) <: ProbabilitiesEstimator
+    NaiveKernel(x, ϵ::Real; method = KDTree, w = 0, metric = Euclidean()) <: ProbabilitiesEstimator
 
 Estimate probabilities/entropy using a "naive" kernel density estimation approach (KDE), as
 discussed in Prichard and Theiler (1995) [^PrichardTheiler1995].
@@ -19,7 +19,7 @@ P_i( X, \\epsilon) \\approx \\dfrac{1}{N} \\sum_{s} B(||X_i - X_j|| < \\epsilon)
 where ``B`` gives 1 if the argument is `true`. Probabilities are then normalized.
 
 ## Keyword arguments
-- `ss = KDTree`: the search structure supported by Neighborhood.jl.
+- `method = KDTree`: the search structure supported by Neighborhood.jl.
   Specifically, use `KDTree` to use a tree-based neighbor search, or `BruteForce` for
   the direct distances between all points. KDTrees heavily outperform direct distances
   when the dimensionality of the data is much smaller than the data length.
@@ -47,6 +47,10 @@ function NaiveKernel(x, ϵ::Real; method = KDTree, w = 0, metric = Euclidean())
     ϵ > 0 || error("Radius ϵ must be larger than zero!")
     return NaiveKernel(ϵ, method, w, metric, eachindex(x))
 end
+
+NaiveKernel(ϵ::Real; kwargs...) =
+    throw(ArgumentError("""NaiveKernel constructor requires input data as the first \
+        argument. Do `NaiveKernel(x, ϵ).`"""))
 
 function probabilities_and_outcomes(est::NaiveKernel, x::AbstractDataset)
     theiler = Theiler(est.w)

--- a/test/complexity/measures/missing_dispersion.jl
+++ b/test/complexity/measures/missing_dispersion.jl
@@ -7,21 +7,13 @@ rng = MersenneTwister(1234)
 # Their values:
 x = [12, 5, 2, 1.5, -1, 3.8, 9, 10, 4.5, 0.9, 8, 2.99]
 s = [3, 2, 1, 1, 1, 2, 3, 3, 2, 1, 3, 1]
-# There might be a typo in the paper. With the same Gaussian symbolization parameters,
-# we get an identical symbol sequence, with the exception of the one element. To see this,
-# run count(!isone, outcomes(x, est.symbolization) .== s), which gives 1 as a result.
-#
-# In the following, I'll assume that this is a typo from their side, because the
-# symbolization they claim to use is the same as for the `Dispersion` estimator,
-# which we analytically test elsewhere using test cases from the original paper.
 dispest = Dispersion(c = 3, m = 2)
 est = MissingDispersionPatterns(dispest)
-# If we take *our* discretized sequence with m = 2,
-# s = [3, 2, 1, 1, 1, 2, 3, 3, 2, 1, 3, 1],
-# then the symbols (3, 1) and (2, 2) don't occur, so the number of missing dispersion
-# patterns is 2, not 1 (as in the paper).
-@test complexity(est, x) == 2.0
-@test complexity_normalized(est, x) == 2/9
+# If we embed take the discretized sequence s = [3, 2, 1, 1, 1, 2, 3, 3, 2, 1, 3, 1],
+# with m = 2 and τ = 1, hen the symbol (2, 2) doesn't occur, so the number of missing
+# dispersion patterns is 1
+@test complexity(est, x) == 1
+@test complexity_normalized(est, x) == 1/9
 
 # For uniformly distributed noise, with sufficiently low-dimensional embeddings and
 # few enough categories for the symbolization, it is expected that all dispersion patterns

--- a/test/probabilities/estimators/dispersion.jl
+++ b/test/probabilities/estimators/dispersion.jl
@@ -1,7 +1,7 @@
 using Entropies
 using Test
-import DelayEmbeddings
-
+using Statistics: mean, std
+using DelayEmbeddings
 @testset "Dispersion" begin
 
     @testset "Internals" begin
@@ -11,10 +11,11 @@ import DelayEmbeddings
         c = 4
         m = 4
         τ = 1
-        s = GaussianCDFEncoding(c)
+        σ, μ = std(x), mean(x)
+        encoding = GaussianCDFEncoding(; σ, μ, c)
 
-        # Symbols should be in the set [1, 2, …, c].
-        symbols = outcomes(x, s)
+        # Encoded symbols should be in the set [1, 2, …, c].
+        symbols = Entropies.encode.(Ref(encoding), x)
         @test all([s ∈ collect(1:c) for s in symbols])
 
         # Dispersion patterns should have a normalized histogram that sums to 1.0.

--- a/test/probabilities/estimators/naive_kernel.jl
+++ b/test/probabilities/estimators/naive_kernel.jl
@@ -1,13 +1,13 @@
 using Entropies.DelayEmbeddings.Neighborhood: KDTree
 
-@test NaiveKernel(0.1) isa NaiveKernel
-@test NaiveKernel(0.1, KDTree) isa NaiveKernel
+@test_throws ArgumentError NaiveKernel(0.1) isa NaiveKernel
+@test_throws ArgumentError NaiveKernel(0.1, method = KDTree) isa NaiveKernel
 
 N = 1000
 pts = Dataset([rand(2) for i = 1:N]);
 ϵ = 0.3
-est_direct = NaiveKernel(ϵ, KDTree)
-est_tree = NaiveKernel(ϵ, BruteForce)
+est_direct = NaiveKernel(pts, ϵ, method = KDTree)
+est_tree = NaiveKernel(pts, ϵ, method = BruteForce)
 
 @test probabilities(est_tree, pts) isa Probabilities
 @test probabilities(est_direct, pts) isa Probabilities
@@ -20,4 +20,4 @@ p_direct = probabilities(est_direct, pts)
 
 probs, z = probabilities_and_outcomes(est_tree, pts)
 @test z == 1:length(pts)
-@test outcome_space(pts, est_tree) == 1:length(pts)
+@test outcome_space(est_tree) == 1:length(pts)


### PR DESCRIPTION
I have now adjusted the codebase so that `GaussianCDFEncoding` obeys the encoding API. This addresses another point in #190.

- Previously, `GaussianCDFEncoding` was only applicable to vector-valued input, meaning that we had to encode an entire timeseries in bulk. By adjusting the type from `GaussianCDFEncoding(; c::Int = 3)` to `GaussianCDFEncoding(; μ, σ, c::Int = 3)`, we now require the user to explicitly specify the mean and standard deviation of the desired normal CDF. Thus, `encode` and `decode` now both handle scalar-valued inputs (i.e. no need for entire timeseries, because `μ` and `σ` must be pre-computed). 
- In  the `Dispersion` struct, instead of explicitly constructing an encoding (i.e. `GaussianCDFEncoding)`, we just use `c::Int`, which dictates how many bins to divide the range of the CDF into. However, we add a field `encoding`, which specifies a *type* of encoding, and can be any encoding type that accepts the keyword `c`. The default is `GaussianCDFEncoding`. It is now trivial to replace `GaussianCDFEncoding` with `WhateverCDFEncoding`, by just doing e.g. `Dispersion(; encoding = WhateverCDFEncoding, c = 5)`. Internally, this will instantiate a `WhateverCDFEncoding(; c = 5)` in the relevant location in the code. However, the `encoding` field is not yet part of the public API. I don't think it should be public yet either, because I have an idea to make this even more generic.
- Empirical mean and standard deviation computations for `Dispersion` are delegated to `symbolize_for_dispersion`, which also instantiates the encoding.
- I let the linear mapping from the `(0, 1)` range of the CDF to the integers `1, 2, ..., c` to just use an equidistant binning. This is essentially a `FixedRectangularBinning(0, 1, c)` (but without explicitly constructing a `RectangularBinEncoding, since it would have to be constructed once per encoding, which is expensive). This differs slightly from the original paper, but makes much more sense. This choice is now well documented, and makes much more intuitive sense than the previous mapping.

The alternative to this entire approach would be to extend the encoding API to be defined for vector-valued inputs, which I don't want to do, because it complicates things unnecessarily. I think the approach here is more elegant anyways, because it is now trivial to user some other encoding by just specifying the `encoding` keyword to `Dispersion` (again, this is not in the public API atm).

Other stuff:
- Fixed some more `NaiveKernel` tests.

- [x] Test pass.
- [x] Documentation generation is successful.

@datseris I will merge this immediately when CI is done, so I can finish up #126 (which depends on this stuff). If you have any comments, just leave them here (or open issues if necessary), and I will address them while working on #126. 