### PR TITLE
Outcome space for `SpatialDispersion` and `SpatialSymbolicPermutation`

### DIFF
--- a/src/probabilities.jl
+++ b/src/probabilities.jl
@@ -78,6 +78,7 @@ All currently implemented probability estimators are:
 - [`ValueHistogram`](@ref).
 - [`TransferOperator`](@ref).
 - [`Dispersion`](@ref).
+- [`SpatialDispersion`](@ref).
 - [`WaveletOverlap`](@ref).
 - [`PowerSpectrum`](@ref).
 - [`SymbolicPermutation`](@ref).

--- a/src/probabilities_estimators/dispersion/dispersion.jl
+++ b/src/probabilities_estimators/dispersion/dispersion.jl
@@ -49,10 +49,10 @@ always get non-zero probabilities using the `Dispersion` probability estimator.
 
 ## Outcome space
 
-The outcome space for `Dispersion` is the unique delay vectors with elements the
+The outcome space for `Dispersion` is the unique delay vectors whose elements are the
 the symbols (integers) encoded by the Gaussian CDF.
 Hence, the outcome space is all `m`-dimensional delay vectors whose elements
-are all possible values in `1:c`.
+are all possible values in `1:c`. There are `c ^ m` such vectors.
 
 ## Data requirements and parameters
 

--- a/src/probabilities_estimators/spatial/spatial_dispersion/SpatialDispersion.jl
+++ b/src/probabilities_estimators/spatial/spatial_dispersion/SpatialDispersion.jl
@@ -11,17 +11,26 @@ import Base.maximum
         L = nothing,
     )
 
-A dispersion-based probabilities/entropy estimator for `N`-dimensional spatiotemporal
-systems, based on Azami et al. (2019)'s 2D square dispersion entropy estimator,
-but here generalized for `N`-dimensional input data `x` (similar to [`Dispersion`](@ref),
-but accepts higher-order arrays as input).
+A dispersion-based probabilities estimator that generalises [`Dispersion`](@ref) for
+input data that are high-dimensional arrays.
+
+`SpatialDispersion` is based on Azami et al. (2019)[^Azami2019]'s 2D square dispersion
+(Shannon) entropy estimator, but is here implemented as a pure probabilities
+probabilities estimator that is generalized for `N`-dimensional input data `x`,
+with arbitrary neighborhood regions (stencils) and (optionally) periodic boundary
+conditions.
+
+In combination with [`entropy`](@ref) and [`entropy_normalized`](@ref), this probabilities
+estimator can be used to compute (normalized) generalized spatiotemporal dispersion
+[`Entropy`](@ref) of any type.
 
 ## Arguments
 
 - `stencil`. Defines what local area (hyperrectangle), or which points within this area,
     to include around each hypervoxel (i.e. pixel in 2D). The examples below demonstrate
     different ways of specifying stencils. For details, see
-    [`SpatialSymbolicPermutation`](@ref).
+    [`SpatialSymbolicPermutation`](@ref). See [`SpatialSymbolicPermutation`](@ref) for
+    more information about stencils.
 -  `x::AbstractArray`. The input data. Must be provided because we need to know its size
     for optimization and bound checking.
 
@@ -54,8 +63,8 @@ Estimating probabilities/entropies from higher-dimensional data is conceptually 
 1. Discretize each value (hypervoxel) in `x` relative to all other values `xᵢ ∈ x` using the
     provided `encoding` scheme.
 2. Use `stencil` to extract relevant (discretized) points around each hypervoxel.
-3. Construct a symbol string from these points.
-4. Take the sum-normalized histogram of the symbol strings as a probability distribution.
+3. Construct a symbol these points.
+4. Take the sum-normalized histogram of the symbol as a probability distribution.
 5. Optionally, compute [`entropy`](@ref) or [`entropy_normalized`](@ref) from this
     probability distribution.
 
@@ -90,6 +99,16 @@ imgs = [rand(50, 50) for i = 1:100]; # one image per second over 100 seconds
 stencil = ((2, 2), (1, 1)) # a 2x2 stencil (i.e. dispersion patterns of length 4)
 est = SpatialDispersion(stencil, first(imgs))
 h_vs_t = entropy_normalized.(Ref(est), imgs)
+```
+
+
+Computing generalized spatiotemporal dispersion entropy is trivial, e.g. with
+[`Renyi`](@ref):
+
+```julia
+x = reshape(repeat(1:5, 500) .+ 0.1*rand(500*5), 50, 50)
+est = SpatialDispersion(stencil, x)
+entropy(Renyi(q = 2), est, x)
 ```
 
 See also: [`SpatialSymbolicPermutation`](@ref), [`GaussianCDFEncoding`](@ref),

--- a/src/probabilities_estimators/spatial/spatial_dispersion/SpatialDispersion.jl
+++ b/src/probabilities_estimators/spatial/spatial_dispersion/SpatialDispersion.jl
@@ -13,7 +13,8 @@ import Base.maximum
 
 A dispersion-based probabilities/entropy estimator for `N`-dimensional spatiotemporal
 systems, based on Azami et al. (2019)'s 2D square dispersion entropy estimator,
-but here generalized for `N`-dimensional input data `x`.
+but here generalized for `N`-dimensional input data `x` (similar to [`Dispersion`](@ref),
+but accepts higher-order arrays as input).
 
 ## Arguments
 
@@ -29,8 +30,7 @@ but here generalized for `N`-dimensional input data `x`.
 - `periodic::Bool`. If `periodic == true`, then the stencil should wrap around at the
     end of the array. If `periodic = false`, then pixels whose stencil exceeds the array
     bounds are skipped.
-- `encoding::Encoding`. Determines how input data is mapped to discrete categories. Must be
-    a valid [`Encoding`](@ref).
+- `c::Int`. Determines how many discrete categories to use for the Gaussian encoding.
 - `skip_encoding`. If `skip_encoding == true`, `encoding` is ignored, and dispersion
     patterns are computed directly from `x`, under the assumption that `L` is the alphabet
     length for `x` (useful for categorical or integer data). Thus, if
@@ -39,6 +39,13 @@ but here generalized for `N`-dimensional input data `x`.
 - `L`. If `L == nothing` (default), then the number of total outcomes is inferred from
     `stencil` and `encoding`. If `L` is set to an integer, then the data is considered
     pre-encoded and the number of total outcomes is set to `L`.
+
+## Outcome space
+
+The outcome space for `SpatialDispersion` is the unique delay vectors whose elements are the
+the symbols (integers) encoded by the Gaussian CDF. Hence, the outcome space is all
+`m`-dimensional delay vectors whose elements are all possible values in `1:c`.
+There are `c ^ m` such vectors.
 
 ## Description
 
@@ -183,7 +190,4 @@ function total_outcomes(est::SpatialDispersion)::Int
     end
 end
 
-# TODO: how to represent the outcomes? We have to think about this...
-function outcome_space(est::SpatialDispersion)
-
-end
+outcome_space(est::SpatialDispersion) = outcome_space(Dispersion(; c = est.c, m = est.m))

--- a/test/probabilities/estimators/spatial/spatial_dispersion.jl
+++ b/test/probabilities/estimators/spatial/spatial_dispersion.jl
@@ -53,3 +53,5 @@ est_y_presymb = SpatialDispersion(stencil, y; skip_encoding =  true, L = 2)
 
 @test 0.99 <= round(entropy_normalized(est_y, y), digits = 2) <= 1.0
 @test 0.99 <= round(entropy_normalized(est_y_presymb, y), digits = 2) <= 1.0
+
+@test outcome_space(est_y) == outcome_space(Dispersion(c = est_y.c, m = est_y.m))

--- a/test/probabilities/estimators/spatial/spatial_permutation.jl
+++ b/test/probabilities/estimators/spatial/spatial_permutation.jl
@@ -81,4 +81,4 @@ est = SpatialSymbolicPermutation(stencil, x)
 hsp = entropy_normalized(Renyi(), est, x)
 @test round(hsp, digits = 2) == 1.00
 
-@test outcome_space(est) == outcome_space(SymbolicPermutation(m = est_y.m))
+@test outcome_space(est) == outcome_space(SymbolicPermutation(m = est.m))

--- a/test/probabilities/estimators/spatial/spatial_permutation.jl
+++ b/test/probabilities/estimators/spatial/spatial_permutation.jl
@@ -80,3 +80,5 @@ stencil = [1 1; 1 1];
 est = SpatialSymbolicPermutation(stencil, x)
 hsp = entropy_normalized(Renyi(), est, x)
 @test round(hsp, digits = 2) == 1.00
+
+@test outcome_space(est) == outcome_space(SymbolicPermutation(m = est_y.m))


### PR DESCRIPTION
Fix #173 