### PR TITLE
Differential entropy estimators: various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The API for Entropies.jl has been completely overhauled. Major changes are:
 - Common generic interfaces `entropy`, `entropy_normalized` and `maximum` (maximum entropy) that dispatches on different types of entropies (e.g `Renyi()` `Shannon()`, `Tsallis()`).
 - Convenience functions for common entropies, such as permutation entropy and dispersion entropy.
 - No more deprecation warnings for using the old keyword `α` for Renyi entropy.
+- The `base` of the entropy is now a field of the `Entropy` type, not the estimator. 
+    You'll now have to do `entropy(Shannon(; base = 2), est, x)`.
 - An entirely new section of entropy-like complexity measures, such as the reverse dispersion entropy.
 - Many new estimators, such as `SpatialPermutation` and `PowerSpectrum`.
 - Check the online documentation for a comprehensive overview of the changes.

--- a/docs/src/entropies.md
+++ b/docs/src/entropies.md
@@ -53,9 +53,7 @@ rely on estimating some density functional.
 
 Each [`EntropyEstimator`](@ref)s uses a specialized technique to approximating relevant
 densities/integrals, and is often tailored to one or a few types of generalized entropy.
-For example, [`Kraskov`](@ref) estimates the [`Shannon`](@ref) entropy, while
-[`LeonenkoProzantoSavani`](@ref) estimates [`Shannon`](@ref), [`Renyi`](@ref), and
-[`Tsallis`](@ref) entropies.
+For example, [`Kraskov`](@ref) estimates the [`Shannon`](@ref) entropy.
 
 | Estimator                    | Principle         | Input data | [`Shannon`](@ref) | [`Renyi`](@ref) | [`Tsallis`](@ref) | [`Kaniadakis`](@ref) | [`Curado`](@ref) | [`StretchedExponential`](@ref) |
 | ---------------------------- | ----------------- | ---------- | :---------------: | :-------------: | :---------------: | :------------------: | :--------------: | :----------------------------: |

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -25,26 +25,33 @@ ax.zticklabelsvisible = false
 fig
 ```
 
-## Differential entropy: nearest neighbors estimators
+## Differential entropy: estimator comparison
 
-Here, we reproduce Figure 1 in Charzyńska & Gambin (2016)[^Charzyńska2016]. Their example
-demonstrates how the [`Kraskov`](@ref) and [`KozachenkoLeonenko`](@ref) nearest neighbor
-based estimators converge towards the true entropy value for increasing time series length.
-We extend their example with [`Zhu`](@ref) and [`ZhuSingh`](@ref) estimators, which are also
-based on nearest neighbor searches.
+Here, we compare how the nearest neighbor differential entropy estimators
+([`Kraskov`](@ref), [`KozachenkoLeonenko`](@ref), [`Zhu`](@ref) and [`ZhuSingh`](@ref))
+converge towards the true entropy value for increasing time series length.
 
-Input data are from a uniform 1D distribution ``U(0, 1)``, for which the true entropy is
-`ln(1 - 0) = 0`).
+Entropies.jl also provides entropy estimators based on
+[order statistics](https://en.wikipedia.org/wiki/Order_statistic). These estimators
+are only defined for scalar-valued vectors, in this example, so we compute these
+estimates separately, and add these estimators ([`Vasicek`](@ref), [`Ebrahimi`](@ref),
+[`AlizadehArghami`](@ref) and [`Correa`](@ref)) to the comparison.
+
+Input data are from a normal 1D distribution ``\mathcal{N}(0, 1)``, for which the true
+entropy is `0.5*log(2π) + 0.5` nats when using natural logarithms.
 
 ```@example MAIN
 using Entropies
 using DynamicalSystemsBase, CairoMakie, Statistics
-using Distributions: Uniform, Normal
+nreps = 30
+Ns = [100:100:500; 1000:1000:10000]
+e = Shannon(; base = MathConstants.e)
 
-# Define estimators
-base = MathConstants.e # shouldn't really matter here, because the target entropy is 0.
+# --------------------------
+# kNN estimators
+# --------------------------
 w = 0 # Theiler window of 0 (only exclude the point itself during neighbor searches)
-estimators = [
+knn_estimators = [
     # with k = 1, Kraskov is virtually identical to
     # Kozachenko-Leonenko, so pick a higher number of neighbors for Kraskov
     Kraskov(; k = 3, w),
@@ -52,92 +59,71 @@ estimators = [
     Zhu(; k = 3, w),
     ZhuSingh(; k = 3, w),
 ]
-labels = ["KozachenkoLeonenko", "Kraskov", "Zhu", "ZhuSingh"]
 
 # Test each estimator `nreps` times over time series of varying length.
-nreps = 50
-Ns = [100:100:500; 1000:1000:10000]
-
-Hs_uniform = [[zeros(nreps) for N in Ns] for e in estimators]
-for (i, e) in enumerate(estimators)
+Hs_uniform_knn = [[zeros(nreps) for N in Ns] for e in knn_estimators]
+for (i, est) in enumerate(knn_estimators)
     for j = 1:nreps
-        pts = rand(Uniform(0, 1), maximum(Ns)) |> Dataset
+        pts = randn(maximum(Ns)) |> Dataset
         for (k, N) in enumerate(Ns)
-            Hs_uniform[i][k][j] = entropy(e, pts[1:N])
+            Hs_uniform_knn[i][k][j] = entropy(e, est, pts[1:N])
         end
     end
 end
 
-fig = Figure(resolution = (600, length(estimators) * 200))
-for (i, e) in enumerate(estimators)
-    Hs = Hs_uniform[i]
-    ax = Axis(fig[i,1]; ylabel = "h (nats)")
-    lines!(ax, Ns, mean.(Hs); color = Cycled(i), label = labels[i])
-    band!(ax, Ns, mean.(Hs) .+ std.(Hs), mean.(Hs) .- std.(Hs);
-    color = (Main.COLORS[i], 0.5))
-    ylims!(-0.25, 0.25)
-    axislegend()
-end
+# --------------------------
+# Order statistic estimators
+# --------------------------
 
-fig
-```
-
-## Differential entropy: order statistics estimators
-
-Entropies.jl also provides entropy estimators based on
-[order statistics](https://en.wikipedia.org/wiki/Order_statistic). These estimators
-are only defined for scalar-valued vectors, so we pass the data as `Vector{<:Real}`s instead
-of `Dataset`s, as we did for the nearest-neighbor estimators above.
-
-Here, we show how the [`Vasicek`](@ref), [`Ebrahimi`](@ref), [`AlizadehArghami`](@ref) 
-and [`Correa`](@ref) direct [`Shannon`](@ref) entropy estimators, with increasing sample size,
-approach zero for samples from a uniform distribution on  `[0, 1]`. The true entropy value in
-nats for this distribution is `ln(1 - 0) = 0`.
-
-```@example MAIN
-using Entropies
-using Statistics
-using Distributions: Uniform
-using CairoMakie
-
-# Define estimators
-base = MathConstants.e # shouldn't really matter here, because the target entropy is 0.
-# just provide types here, they are instantiated inside the loop
-estimators = [Vasicek, Ebrahimi, AlizadehArghami, Correa]
-labels = ["Vasicek", "Ebrahimi", "AlizadehArghami", "Correa"]
-
-# Test each estimator `nreps` times over time series of varying length.
-Ns = [100:100:500; 1000:1000:10000]
-nreps = 30
-
-Hs_uniform = [[zeros(nreps) for N in Ns] for e in estimators]
-for (i, e) in enumerate(estimators)
+# Just provide types here, they are instantiated inside the loop
+estimators_os = [Vasicek, Ebrahimi, AlizadehArghami, Correa]
+Hs_uniform_os = [[zeros(nreps) for N in Ns] for e in estimators_os]
+for (i, est_os) in enumerate(estimators_os)
     for j = 1:nreps
-        pts = rand(Uniform(0, 1), maximum(Ns)) # raw timeseries, not a `Dataset`
+        pts = randn(maximum(Ns)) # raw timeseries, not a `Dataset`
         for (k, N) in enumerate(Ns)
             m = floor(Int, N / 100) # Scale `m` to timeseries length
-            est = e(; m, base) # Instantiate estimator with current `m`
-            Hs_uniform[i][k][j] = entropy(est, pts[1:N])
+            est = est_os(; m) # Instantiate estimator with current `m`
+            Hs_uniform_os[i][k][j] = entropy(e, est, pts[1:N])
         end
     end
 end
 
-fig = Figure(resolution = (600, length(estimators) * 200))
-for (i, e) in enumerate(estimators)
-    Hs = Hs_uniform[i]
+# -------------
+# Plot results
+# -------------
+fig = Figure(resolution = (700, 8 * 200))
+labels_knn = ["KozachenkoLeonenko", "Kraskov", "Zhu", "ZhuSingh"]
+labels_os = ["Vasicek", "Ebrahimi", "AlizadehArghami", "Correa"]
+
+for (i, e) in enumerate(knn_estimators)
+    Hs = Hs_uniform_knn[i]
     ax = Axis(fig[i,1]; ylabel = "h (nats)")
-    lines!(ax, Ns, mean.(Hs); color = Cycled(i), label = labels[i])
-    band!(ax, Ns, mean.(Hs) .+ std.(Hs), mean.(Hs) .- std.(Hs);
-    color = (Main.COLORS[i], 0.5))
-    ylims!(-0.25, 0.25)
+    lines!(ax, Ns, mean.(Hs); color = Cycled(i), label = labels_knn[i])
+    band!(ax, Ns, mean.(Hs) .+ std.(Hs), mean.(Hs) .- std.(Hs); alpha = 0.5,
+        color = (Main.COLORS[i], 0.5))
+    hlines!(ax, [(0.5*log(2π) + 0.5)], color = :black, lw = 5, linestyle = :dash)
+
+    ylims!(1.2, 1.6)
+    axislegend()
+end
+
+for (i, e) in enumerate(estimators_os)
+    Hs = Hs_uniform_os[i]
+    ax = Axis(fig[i + length(knn_estimators),1]; ylabel = "h (nats)")
+    lines!(ax, Ns, mean.(Hs); color = Cycled(i), label = labels_os[i])
+    band!(ax, Ns, mean.(Hs) .+ std.(Hs), mean.(Hs) .- std.(Hs), alpha = 0.5,
+        color = (Main.COLORS[i], 0.5))
+    hlines!(ax, [(0.5*log(2π) + 0.5)], color = :black, lw = 5, linestyle = :dash)
+    ylims!(1.2, 1.6)
     axislegend()
 end
 
 fig
 ```
 
-As for the nearest neighbor estimators, both estimators also approach the
-true entropy value for this example, but is negatively biased for small sample sizes.
+All estimators approach the true differential entropy, but those based on order statistics
+are negatively biased for small sample sizes.
 
 ## Discrete entropy: permutation entropy
 
@@ -315,6 +301,7 @@ using Entropies
 using DynamicalSystemsBase
 using Random
 using CairoMakie
+using Distributions: Normal
 
 n = 1000
 ts = 1:n

--- a/src/entropies/estimators/nearest_neighbors/KozachenkoLeonenko.jl
+++ b/src/entropies/estimators/nearest_neighbors/KozachenkoLeonenko.jl
@@ -5,9 +5,22 @@ export KozachenkoLeonenko
     KozachenkoLeonenko(; k::Int = 1, w::Int = 1, base = 2)
 
 The `KozachenkoLeonenko` estimator computes the [`Shannon`](@ref) differential
-[`entropy`](@ref) of `x` (a multi-dimensional `Dataset`) to the given `base`, based on
-nearest neighbor searches using the method from Kozachenko & Leonenko
-(1987)[^KozachenkoLeonenko1987], as described in Charzyńska and Gambin[^Charzyńska2016].
+[`entropy`](@ref) of `x` (a multi-dimensional `Dataset`) to the given `base`.
+
+## Description
+
+Assume we have samples ``\\{\\bf{x}_1, \\bf{x}_2, \\ldots, \\bf{x}_N \\}`` from a
+continuous random variable ``X \\in \\mathbb{R}^d`` with support ``\\mathcal{X}`` and
+density function``f : \\mathbb{R}^d \\to \\mathbb{R}``. `KozachenkoLeonenko` estimates
+the [Shannon](@ref) differential entropy
+
+```math
+H(X) = \\int_{\\mathcal{X}} f(x) \\log f(x) dx = \\mathbb{E}[-\\log(f(X))]
+```
+
+using the nearest neighbor method from Kozachenko &
+Leonenko (1987)[^KozachenkoLeonenko1987], as described in Charzyńska and
+Gambin[^Charzyńska2016].
 
 `w` is the Theiler window, which determines if temporal neighbors are excluded
 during neighbor searches (defaults to `0`, meaning that only the point itself is excluded
@@ -15,7 +28,8 @@ when searching for neighbours).
 
 In contrast to [`Kraskov`](@ref), this estimator uses only the *closest* neighbor.
 
-See also: [`entropy`](@ref).
+
+See also: [`entropy`](@ref), [`Kraskov`](@ref), [`EntropyEstimator`](@ref).
 
 [^Charzyńska2016]: Charzyńska, A., & Gambin, A. (2016). Improvement of the k-NN entropy
     estimator with applications in systems biology. Entropy, 18(1), 13.

--- a/src/entropies/estimators/nearest_neighbors/KozachenkoLeonenko.jl
+++ b/src/entropies/estimators/nearest_neighbors/KozachenkoLeonenko.jl
@@ -2,10 +2,10 @@ export KozachenkoLeonenko
 
 """
     KozachenkoLeonenko <: EntropyEstimator
-    KozachenkoLeonenko(; k::Int = 1, w::Int = 1, base = 2)
+    KozachenkoLeonenko(; k::Int = 1, w::Int = 1)
 
 The `KozachenkoLeonenko` estimator computes the [`Shannon`](@ref) differential
-[`entropy`](@ref) of `x` (a multi-dimensional `Dataset`) to the given `base`.
+[`entropy`](@ref) of `x` (a multi-dimensional `Dataset`).
 
 ## Description
 
@@ -36,16 +36,15 @@ See also: [`entropy`](@ref), [`Kraskov`](@ref), [`EntropyEstimator`](@ref).
 [^KozachenkoLeonenko1987]: Kozachenko, L. F., & Leonenko, N. N. (1987). Sample estimate of
     the entropy of a random vector. Problemy Peredachi Informatsii, 23(2), 9-16.
 """
-@Base.kwdef struct KozachenkoLeonenko{B} <: EntropyEstimator
+@Base.kwdef struct KozachenkoLeonenko <: EntropyEstimator
     w::Int = 1
-    base::B = 2
 end
 
 function entropy(e::Renyi, est::KozachenkoLeonenko, x::AbstractDataset{D, T}) where {D, T}
     e.q == 1 || throw(ArgumentError(
         "Renyi entropy with q = $(e.q) not implemented for $(typeof(est)) estimator"
     ))
-    (; w, base) = est
+    (; w) = est
 
     N = length(x)
     ρs = maximum_neighbor_distances(x, w, 1)
@@ -54,5 +53,5 @@ function entropy(e::Renyi, est::KozachenkoLeonenko, x::AbstractDataset{D, T}) wh
         log(MathConstants.e, ball_volume(D)) +
         MathConstants.eulergamma +
         log(MathConstants.e, N - 1)
-    return h / log(base, MathConstants.e) # Convert to target unit
+    return h / log(e.base, MathConstants.e) # Convert to target unit
 end

--- a/src/entropies/estimators/nearest_neighbors/Kraskov.jl
+++ b/src/entropies/estimators/nearest_neighbors/Kraskov.jl
@@ -12,7 +12,18 @@ searches method from [^Kraskov2004].
 during neighbor searches (defaults to `0`, meaning that only the point itself is excluded
 when searching for neighbours).
 
-See also: [`entropy`](@ref), [`KozachenkoLeonenko`](@ref).
+## Description
+
+Assume we have samples ``\\{\\bf{x}_1, \\bf{x}_2, \\ldots, \\bf{x}_N \\}`` from a
+continuous random variable ``X \\in \\mathbb{R}^d`` with support ``\\mathcal{X}`` and
+density function``f : \\mathbb{R}^d \\to \\mathbb{R}``. `Kraskov` estimates the
+[Shannon](@ref) differential entropy
+
+```math
+H(X) = \\int_{\\mathcal{X}} f(x) \\log f(x) dx = \\mathbb{E}[-\\log(f(X))].
+```
+
+See also: [`entropy`](@ref), [`KozachenkoLeonenko`](@ref), [`EntropyEstimator`](@ref).
 
 [^Kraskov2004]:
     Kraskov, A., Stögbauer, H., & Grassberger, P. (2004).

--- a/src/entropies/estimators/nearest_neighbors/Kraskov.jl
+++ b/src/entropies/estimators/nearest_neighbors/Kraskov.jl
@@ -2,10 +2,10 @@ export Kraskov
 
 """
     Kraskov <: EntropyEstimator
-    Kraskov(; k::Int = 1, w::Int = 1, base = 2)
+    Kraskov(; k::Int = 1, w::Int = 1)
 
 The `Kraskov` estimator computes the [`Shannon`](@ref) differential [`entropy`](@ref) of `x`
-(a multi-dimensional `Dataset`) to the given `base`, using the `k`-th nearest neighbor
+(a multi-dimensional `Dataset`) using the `k`-th nearest neighbor
 searches method from [^Kraskov2004].
 
 `w` is the Theiler window, which determines if temporal neighbors are excluded
@@ -29,22 +29,21 @@ See also: [`entropy`](@ref), [`KozachenkoLeonenko`](@ref), [`EntropyEstimator`](
     Kraskov, A., Stögbauer, H., & Grassberger, P. (2004).
     Estimating mutual information. Physical review E, 69(6), 066138.
 """
-Base.@kwdef struct Kraskov{B} <: EntropyEstimator
+Base.@kwdef struct Kraskov <: EntropyEstimator
     k::Int = 1
     w::Int = 1
-    base::B = 2
 end
 
 function entropy(e::Renyi, est::Kraskov, x::AbstractDataset{D, T}) where {D, T}
     e.q == 1 || throw(ArgumentError(
         "Renyi entropy with q = $(e.q) not implemented for $(typeof(est)) estimator"
     ))
-    (; k, w, base) = est
+    (; k, w) = est
     N = length(x)
     ρs = maximum_neighbor_distances(x, w, k)
     # The estimated entropy has "unit" [nats]
     h = -digamma(k) + digamma(N) +
         log(MathConstants.e, ball_volume(D)) +
         D/N*sum(log.(MathConstants.e, ρs))
-    return h / log(base, MathConstants.e) # Convert to target unit
+    return h / log(e.base, MathConstants.e) # Convert to target unit
 end

--- a/src/entropies/estimators/nearest_neighbors/Zhu.jl
+++ b/src/entropies/estimators/nearest_neighbors/Zhu.jl
@@ -4,18 +4,27 @@ export Zhu
     Zhu <: EntropyEstimator
     Zhu(k = 1, w = 0)
 
-The `Zhu` estimator (Zhu et al., 2015)[^Zhu2015] computes the [`Shannon`](@ref)
-differential [`entropy`](@ref) of `x` (a multi-dimensional `Dataset`), by
-approximating probabilities within hyperrectangles surrounding each point `xᵢ ∈ x` using
-using `k` nearest neighbor searches.
+The `Zhu` estimator (Zhu et al., 2015)[^Zhu2015] is an extension to
+[`KozachenkoLeonenko`](@ref), and computes the [`Shannon`](@ref)
+differential [`entropy`](@ref) of `x` (a multi-dimensional `Dataset`).
 
-`w` is the Theiler window, which determines if temporal neighbors are excluded
-during neighbor searches (defaults to `0`, meaning that only the point itself is excluded
-when searching for neighbours).
+## Description
 
-This estimator is an extension to [`KozachenkoLeonenko`](@ref).
+Assume we have samples ``\\{\\bf{x}_1, \\bf{x}_2, \\ldots, \\bf{x}_N \\}`` from a
+continuous random variable ``X \\in \\mathbb{R}^d`` with support ``\\mathcal{X}`` and
+density function``f : \\mathbb{R}^d \\to \\mathbb{R}``. `Zhu` estimates the [Shannon](@ref)
+differential entropy
 
-See also: [`entropy`](@ref).
+```math
+H(X) = \\int_{\\mathcal{X}} f(x) \\log f(x) dx = \\mathbb{E}[-\\log(f(X))]
+```
+
+by approximating densities within hyperrectangles surrounding each point `xᵢ ∈ x` using
+using `k` nearest neighbor searches. `w` is the Theiler window, which determines if
+temporal neighbors are excluded during neighbor searches (defaults to `0`, meaning that
+only the point itself is excluded when searching for neighbours).
+
+See also: [`entropy`](@ref), [`KozachenkoLeonenko`](@ref), [`EntropyEstimator`](@ref).
 
 [^Zhu2015]:
     Zhu, J., Bellanger, J. J., Shu, H., & Le Bouquin Jeannès, R. (2015). Contribution to

--- a/src/entropies/estimators/nearest_neighbors/ZhuSingh.jl
+++ b/src/entropies/estimators/nearest_neighbors/ZhuSingh.jl
@@ -12,6 +12,17 @@ export ZhuSingh
 The `ZhuSingh` estimator (Zhu et al., 2015)[^Zhu2015] computes the [`Shannon`](@ref)
 differential [`entropy`](@ref) of `x` (a multi-dimensional `Dataset`).
 
+## Description
+
+Assume we have samples ``\\{\\bf{x}_1, \\bf{x}_2, \\ldots, \\bf{x}_N \\}`` from a
+continuous random variable ``X \\in \\mathbb{R}^d`` with support ``\\mathcal{X}`` and
+density function``f : \\mathbb{R}^d \\to \\mathbb{R}``. `ZhuSingh` estimates the
+[Shannon](@ref) differential entropy
+
+```math
+H(X) = \\int_{\\mathcal{X}} f(x) \\log f(x) dx = \\mathbb{E}[-\\log(f(X))].
+```
+
 Like [`Zhu`](@ref), this estimator approximates probabilities within hyperrectangles
 surrounding each point `xᵢ ∈ x` using using `k` nearest neighbor searches. However,
 it also considers the number of neighbors falling on the borders of these hyperrectangles.

--- a/src/entropies/estimators/order_statistics/AlizadehArghami.jl
+++ b/src/entropies/estimators/order_statistics/AlizadehArghami.jl
@@ -57,8 +57,8 @@ function entropy(e::Renyi, est::AlizadehArghami, x::AbstractVector{T}) where T
         "Renyi entropy with q = $(e.q) not implemented for $(typeof(est)) estimator"
     ))
 
-    (; m, base) = est
+    (; m) = est
     n = length(x)
     m < floor(Int, n / 2) || throw(ArgumentError("Need m < length(x)/2."))
-    return entropy(Vasicek(; m, e.base), x) + (2 / n)*(m * log(base, 2))
+    return entropy(e, Vasicek(; m), x) + (2 / n)*(m * log(e.base, 2))
 end

--- a/src/entropies/estimators/order_statistics/AlizadehArghami.jl
+++ b/src/entropies/estimators/order_statistics/AlizadehArghami.jl
@@ -60,5 +60,6 @@ function entropy(e::Renyi, est::AlizadehArghami, x::AbstractVector{T}) where T
     (; m) = est
     n = length(x)
     m < floor(Int, n / 2) || throw(ArgumentError("Need m < length(x)/2."))
-    return entropy(e, Vasicek(; m), x) + (2 / n)*(m * log(e.base, 2))
+    h = entropy(Renyi(base = ℯ, q = e.q), Vasicek(; m), x) + (2 / n)*(m * log(2))
+    return h / log(e.base, ℯ)
 end

--- a/src/entropies/estimators/order_statistics/Correa.jl
+++ b/src/entropies/estimators/order_statistics/Correa.jl
@@ -2,52 +2,69 @@ export Correa
 
 """
     Correa <: EntropyEstimator
-    Correa(; m::Int = 1, base = 2)
+    Correa(; m::Int = 1)
 
 The `Correa` estimator computes the [`Shannon`](@ref) differential [`entropy`](@ref) of `x`
-(a multi-dimensional `Dataset`) to the given `base` using the method from
-Correa (1995)[^Correa1995].
+(a multi-dimensional `Dataset`) using the method from Correa (1995)[^Correa1995].
+
+The `Correa` estimator belongs to a class of differential entropy estimators based
+on [order statistics](https://en.wikipedia.org/wiki/Order_statistic). It only works for
+*timeseries* input.
 
 ## Description
 
-The Correa entropy estimator first computes the order statistics like [`Vasicek`](@ref),
-ensuring that edge points are included, then estimates entropy as
+Assume we have samples ``\\bar{X} = \\{x_1, x_2, \\ldots, x_N \\}`` from a
+continuous random variable ``X \\in \\mathbb{R}`` with support ``\\mathcal{X}`` and
+density function``f : \\mathbb{R} \\to \\mathbb{R}``. `Correa` estimates the
+[Shannon](@ref) differential entropy
 
 ```math
-H_C(m, n) =
+H(X) = \\int_{\\mathcal{X}} f(x) \\log f(x) dx = \\mathbb{E}[-\\log(f(X))].
+```
+
+However, instead of estimating the above integral directly, `Correa` makes use of the
+equivalent integral, where ``F`` is the distribution function for ``X``,
+
+```math
+H(X) = \\int_0^1 \\log \\left(\\dfrac{d}{dp}F^{-1}(p) \\right) dp
+```
+
+This integral is approximated by first computing the
+[order statistics](https://en.wikipedia.org/wiki/Order_statistic) of ``\\bar{X}``
+(the input timeseries), i.e. ``x_{(1)} \\leq x_{(2)} \\leq \\cdots \\leq x_{(n)}``,
+ensuring that end points are included. The `Correa` estimate of [`Shannon`](@ref)
+differential entropy is then
+
+```math
+H_C(\\bar{X}, m, n) =
 \\dfrac{1}{n} \\sum_{i = 1}^n \\log
-\\left[ \\dfrac{ \\sum_{j=i-m}^{i+m}(X_{(j)} - \\bar{X}_{(i)})(j - i)}{n \\sum_{j=i-m}^{i+m} (X_{(j)} - \\bar{X}_{(i)})^2} \\right],
+\\left[ \\dfrac{ \\sum_{j=i-m}^{i+m}(\\bar{X}_{(j)} -
+\\tilde{X}_{(i)})(j - i)}{n \\sum_{j=i-m}^{i+m} (\\bar{X}_{(j)} - \\tilde{X}_{(i)})^2}
+\\right],
 ```
 
 where
 
 ```math
-\\bar{X}_{(i)} = \\dfrac{1}{2m + 1} \\sum_{j = i - m}^{i + m} X_{(j)}.
+\\tilde{X}_{(i)} = \\dfrac{1}{2m + 1} \\sum_{j = i - m}^{i + m} X_{(j)}.
 ```
 
 [^Correa1995]:
     Correa, J. C. (1995). A new estimator of entropy. Communications in Statistics-Theory
     and Methods, 24(10), 2439-2449.
+
+See also: [`entropy`](@ref), [`AlizadehArghami`](@ref), [`Ebrahimi`](@ref),
+[`Vasicek`](@ref), [`EntropyEstimator`](@ref).
 """
-@Base.kwdef struct Correa{I<:Integer, B} <: EntropyEstimator
+@Base.kwdef struct Correa{I<:Integer} <: EntropyEstimator
     m::I = 1
-    base::B = 2
-end
-
-function local_scaled_mean(ex, i::Int, m::Int, n::Int = length(x))
-    x̄ = 0.0
-    for j in (i - m):(i + m)
-        x̄ += ith_order_statistic(ex, j, n) # ex[j] would cause out-of-bounds errors
-    end
-
-    return x̄ / (2m + 1)
 end
 
 function entropy(e::Renyi, est::Correa, x::AbstractVector{T}) where T
     e.q == 1 || throw(ArgumentError(
         "Renyi entropy with q = $(e.q) not implemented for $(typeof(est)) estimator"
     ))
-    (; m, base) = est
+    (; m) = est
     n = length(x)
     m < floor(Int, n / 2) || throw(ArgumentError("Need m < length(x)/2."))
 
@@ -63,7 +80,16 @@ function entropy(e::Renyi, est::Correa, x::AbstractVector{T}) where T
             den += (xⱼ - x̄ᵢ)^2
         end
         den *= n
-        HCₘₙ += log(base, num / den)
+        HCₘₙ += log(e.base, num / den)
     end
     return -HCₘₙ / n
+end
+
+function local_scaled_mean(ex, i::Int, m::Int, n::Int = length(x))
+    x̄ = 0.0
+    for j in (i - m):(i + m)
+        x̄ += ith_order_statistic(ex, j, n) # ex[j] would cause out-of-bounds errors
+    end
+
+    return x̄ / (2m + 1)
 end

--- a/src/entropies/estimators/order_statistics/Correa.jl
+++ b/src/entropies/estimators/order_statistics/Correa.jl
@@ -80,9 +80,9 @@ function entropy(e::Renyi, est::Correa, x::AbstractVector{T}) where T
             den += (xⱼ - x̄ᵢ)^2
         end
         den *= n
-        HCₘₙ += log(e.base, num / den)
+        HCₘₙ += log(num / den)
     end
-    return -HCₘₙ / n
+    return (-HCₘₙ / n) / log(e.base, ℯ)
 end
 
 function local_scaled_mean(ex, i::Int, m::Int, n::Int = length(x))

--- a/src/entropies/estimators/order_statistics/Ebrahimi.jl
+++ b/src/entropies/estimators/order_statistics/Ebrahimi.jl
@@ -87,7 +87,7 @@ function entropy(e::Renyi, est::Ebrahimi, x::AbstractVector{T}) where T
         f = n / (cᵢ * m)
         dnext = ith_order_statistic(ex, i + m, n)
         dprev = ith_order_statistic(ex, i - m, n)
-        HVₘₙ += log(e.base, f * (dnext - dprev))
+        HVₘₙ += log(f * (dnext - dprev))
     end
-    return HVₘₙ / n
+    return (HVₘₙ / n) / log(e.base, ℯ)
 end

--- a/src/entropies/estimators/order_statistics/Ebrahimi.jl
+++ b/src/entropies/estimators/order_statistics/Ebrahimi.jl
@@ -2,22 +2,42 @@ export Ebrahimi
 
 """
     Ebrahimi <: EntropyEstimator
-    Ebrahimi(; m::Int = 1, base = 2)
+    Ebrahimi(; m::Int = 1)
 
 The `Ebrahimi` estimator computes the [`Shannon`](@ref) [`entropy`](@ref) of `x`
-(a multi-dimensional `Dataset`) to the given `base` using the method from
-Ebrahimi (1994)[^Ebrahimi1994].
+(a multi-dimensional `Dataset`) using the method from Ebrahimi (1994)[^Ebrahimi1994].
 
+The `Ebrahimi` estimator belongs to a class of differential entropy estimators based
+on [order statistics](https://en.wikipedia.org/wiki/Order_statistic). It only works for
+*timeseries* input.
 
 ## Description
 
-The Ebrahimi entropy estimator first computes the order statistics
-``X_{(1)} \\leq X_{(2)} \\leq \\cdots \\leq X_{(n)}`` for a random sample of length ``n``,
-i.e. the input timeseries. The [`Shannon`](@ref) differential entropy is then estimated as
+Assume we have samples ``\\bar{X} = \\{x_1, x_2, \\ldots, x_N \\}`` from a
+continuous random variable ``X \\in \\mathbb{R}`` with support ``\\mathcal{X}`` and
+density function``f : \\mathbb{R} \\to \\mathbb{R}``. `Ebrahimi` estimates the
+[Shannon](@ref) differential entropy
 
 ```math
-H_{E}(m) =
-\\dfrac{1}{n} \\sum_{i = 1}^n \\log \\left[ \\dfrac{n}{c_i m} (X_{(i+m)} - X_{(i-m)}) \\right],
+H(X) = \\int_{\\mathcal{X}} f(x) \\log f(x) dx = \\mathbb{E}[-\\log(f(X))].
+```
+
+However, instead of estimating the above integral directly, it makes use of the equivalent
+integral, where ``F`` is the distribution function for ``X``,
+
+```math
+H(X) = \\int_0^1 \\log \\left(\\dfrac{d}{dp}F^{-1}(p) \\right) dp
+```
+
+This integral is approximated by first computing the
+[order statistics](https://en.wikipedia.org/wiki/Order_statistic) of ``\\bar{X}``
+(the input timeseries), i.e. ``x_{(1)} \\leq x_{(2)} \\leq \\cdots \\leq x_{(n)}``.
+The `Ebrahimi` [`Shannon`](@ref) differential entropy estimate is then
+
+```math
+\\hat{H}_{E}(\\bar{X}, m) =
+\\dfrac{1}{n} \\sum_{i = 1}^n \\log
+\\left[ \\dfrac{n}{c_i m} (\\bar{X}_{(i+m)} - \\bar{X}_{(i-m)}) \\right],
 ```
 
 where
@@ -25,8 +45,8 @@ where
 ```math
 c_i =
 \\begin{cases}
-    1 + \\frac{i - 1}{m}, & 1 \\geq i \\geq m \\
-    2,                    & m + 1 \\geq i \\geq n - m \\
+    1 + \\frac{i - 1}{m}, & 1 \\geq i \\geq m \\\\
+    2,                    & m + 1 \\geq i \\geq n - m \\\\
     1 + \\frac{n - i}{m} & n - m + 1 \\geq i \\geq n
 \\end{cases}.
 ```
@@ -34,10 +54,12 @@ c_i =
 [^Ebrahimi1994]:
     Ebrahimi, N., Pflughoeft, K., & Soofi, E. S. (1994). Two measures of sample entropy.
     Statistics & Probability Letters, 20(3), 225-234.
+
+See also: [`entropy`](@ref), [`Correa`](@ref), [`AlizadehArghami`](@ref),
+[`Vasicek`](@ref), [`EntropyEstimator`](@ref).
 """
-@Base.kwdef struct Ebrahimi{I<:Integer, B} <: EntropyEstimator
+@Base.kwdef struct Ebrahimi{I<:Integer} <: EntropyEstimator
     m::I = 1
-    base::B = 2
 end
 
 function ebrahimi_scaling_factor(i, m, n)
@@ -54,7 +76,7 @@ function entropy(e::Renyi, est::Ebrahimi, x::AbstractVector{T}) where T
     e.q == 1 || throw(ArgumentError(
         "Renyi entropy with q = $(e.q) not implemented for $(typeof(est)) estimator"
     ))
-    (; m, base) = est
+    (; m) = est
     n = length(x)
     m < floor(Int, n / 2) || throw(ArgumentError("Need m < length(x)/2."))
 
@@ -65,7 +87,7 @@ function entropy(e::Renyi, est::Ebrahimi, x::AbstractVector{T}) where T
         f = n / (cᵢ * m)
         dnext = ith_order_statistic(ex, i + m, n)
         dprev = ith_order_statistic(ex, i - m, n)
-        HVₘₙ += log(base, f * (dnext - dprev))
+        HVₘₙ += log(e.base, f * (dnext - dprev))
     end
     return HVₘₙ / n
 end

--- a/src/entropies/estimators/order_statistics/Vasicek.jl
+++ b/src/entropies/estimators/order_statistics/Vasicek.jl
@@ -5,19 +5,39 @@ export Vasicek
     Vasicek(; m::Int = 1, base = 2)
 
 The `Vasicek` estimator computes the [`Shannon`](@ref) differential [`entropy`](@ref) of `x`
-(a multi-dimensional `Dataset`) to the given `base` using the method from
-Vasicek (1976)[^Vasicek1976].
+(a multi-dimensional `Dataset`) using the method from Vasicek (1976)[^Vasicek1976].
+
+The `Vasicek` estimator belongs to a class of differential entropy estimators based
+on [order statistics](https://en.wikipedia.org/wiki/Order_statistic), of which
+Vasicek (1976) was the first. It only works for *timeseries* input.
 
 ## Description
 
-The Vasicek entropy estimator first computes the
-[order statistics](https://en.wikipedia.org/wiki/Order_statistic)
-``X_{(1)} \\leq X_{(2)} \\leq \\cdots \\leq X_{(n)}`` for a random sample of length ``n``,
-i.e. the input timeseries. The [`Shannon`](@ref) entropy is then estimated as
+Assume we have samples ``\\bar{X} = \\{x_1, x_2, \\ldots, x_N \\}`` from a
+continuous random variable ``X \\in \\mathbb{R}`` with support ``\\mathcal{X}`` and
+density function``f : \\mathbb{R} \\to \\mathbb{R}``. `Vasicek` estimates the
+[Shannon](@ref) differential entropy
 
 ```math
-H_V(m) =
-\\dfrac{1}{n} \\sum_{i = 1}^n \\log \\left[ \\dfrac{n}{2m} (X_{(i+m)} - X_{(i-m)}) \\right]
+H(X) = \\int_{\\mathcal{X}} f(x) \\log f(x) dx = \\mathbb{E}[-\\log(f(X))].
+```
+
+However, instead of estimating the above integral directly, it makes use of the equivalent
+integral, where ``F`` is the distribution function for ``X``,
+
+```math
+H(X) = \\int_0^1 \\log \\left(\\dfrac{d}{dp}F^{-1}(p) \\right) dp
+```
+
+This integral is approximated by first computing the
+[order statistics](https://en.wikipedia.org/wiki/Order_statistic) of ``\\bar{X}``
+(the input timeseries), i.e. ``x_{(1)} \\leq x_{(2)} \\leq \\cdots \\leq x_{(n)}``.
+The `Vasicek` [`Shannon`](@ref) differential entropy estimate is then
+
+```math
+\\hat{H}_V(\\bar{X}, m) =
+\\dfrac{1}{n}
+\\sum_{i = 1}^n \\log \\left[ \\dfrac{n}{2m} (\\bar{X}_{(i+m)} - \\bar{X}_{(i-m)}) \\right]
 ```
 
 ## Usage
@@ -30,17 +50,19 @@ written for this package).
 [^Vasicek1976]:
     Vasicek, O. (1976). A test for normality based on sample entropy. Journal of the Royal
     Statistical Society: Series B (Methodological), 38(1), 54-59.
+
+See also: [`entropy`](@ref), [`Correa`](@ref), [`AlizadehArghami`](@ref),
+[`Ebrahimi`](@ref), [`EntropyEstimator`](@ref).
 """
-@Base.kwdef struct Vasicek{I<:Integer, B} <: EntropyEstimator
+@Base.kwdef struct Vasicek{I<:Integer} <: EntropyEstimator
     m::I = 1
-    base::B = 2
 end
 
 function entropy(e::Renyi, est::Vasicek, x::AbstractVector{T}) where T
     e.q == 1 || throw(ArgumentError(
         "Renyi entropy with q = $(e.q) not implemented for $(typeof(est)) estimator"
     ))
-    (; m, base) = est
+    (; m) = est
     n = length(x)
     m < floor(Int, n / 2) || throw(ArgumentError("Need m < length(x)/2."))
 
@@ -50,7 +72,7 @@ function entropy(e::Renyi, est::Vasicek, x::AbstractVector{T}) where T
     for i = 1:n
         dnext = ith_order_statistic(ex, i + m, n)
         dprev = ith_order_statistic(ex, i - m, n)
-        HVₘₙ += log(base, f * (dnext - dprev))
+        HVₘₙ += log(e.base, f * (dnext - dprev))
     end
     return HVₘₙ / n
 end

--- a/src/entropies/estimators/order_statistics/Vasicek.jl
+++ b/src/entropies/estimators/order_statistics/Vasicek.jl
@@ -2,7 +2,7 @@ export Vasicek
 
 """
     Vasicek <: EntropyEstimator
-    Vasicek(; m::Int = 1, base = 2)
+    Vasicek(; m::Int = 1)
 
 The `Vasicek` estimator computes the [`Shannon`](@ref) differential [`entropy`](@ref) of `x`
 (a multi-dimensional `Dataset`) using the method from Vasicek (1976)[^Vasicek1976].

--- a/src/entropies/estimators/order_statistics/Vasicek.jl
+++ b/src/entropies/estimators/order_statistics/Vasicek.jl
@@ -72,7 +72,7 @@ function entropy(e::Renyi, est::Vasicek, x::AbstractVector{T}) where T
     for i = 1:n
         dnext = ith_order_statistic(ex, i + m, n)
         dprev = ith_order_statistic(ex, i - m, n)
-        HVₘₙ += log(e.base, f * (dnext - dprev))
+        HVₘₙ += log(f * (dnext - dprev))
     end
-    return HVₘₙ / n
+    return (HVₘₙ / n) / log(e.base, ℯ)
 end

--- a/test/entropies/estimators/alizadeharghami.jl
+++ b/test/entropies/estimators/alizadeharghami.jl
@@ -6,13 +6,16 @@
 U = 0.00
 # Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
+N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
 
 npts = 1000000
 ea = entropy(Shannon(; base = 2), AlizadehArghami(m = 100), rand(npts))
 ea_n = entropy(Shannon(; base = ℯ), AlizadehArghami(m = 100), randn(npts))
+ea_n3 = entropy(Shannon(; base = 3), AlizadehArghami(m = 100), randn(npts))
 
 @test round(ea, digits = 2) == U
 @test round(ea_n, digits = 2) == N
+@test round(ea_n3, digits = 2) == N_base3
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), AlizadehArghami(), x)

--- a/test/entropies/estimators/alizadeharghami.jl
+++ b/test/entropies/estimators/alizadeharghami.jl
@@ -19,3 +19,7 @@ ea_n3 = entropy(Shannon(; base = 3), AlizadehArghami(m = 100), randn(npts))
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), AlizadehArghami(), x)
+
+# Default is Shannon base-2 differential entropy
+est = AlizadehArghami()
+@test entropy(est, x) == entropy(Shannon(; base = 2), est, x)

--- a/test/entropies/estimators/alizadeharghami.jl
+++ b/test/entropies/estimators/alizadeharghami.jl
@@ -7,12 +7,12 @@ U = 0.00
 # Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
 
-ea = AlizadehArghami(m = 100, base = 2)
-ea_n = AlizadehArghami(m = 100, base = MathConstants.e)
+npts = 1000000
+ea = entropy(Shannon(; base = 2), AlizadehArghami(m = 100), rand(npts))
+ea_n = entropy(Shannon(; base = ℯ), AlizadehArghami(m = 100), randn(npts))
 
-n = 1000000
-@test round(entropy(ea, rand(rng, n)), digits = 2) == U
-@test round(entropy(ea_n, randn(rng, n)), digits = 2) == N
+@test round(ea, digits = 2) == U
+@test round(ea_n, digits = 2) == N
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), AlizadehArghami(), x)

--- a/test/entropies/estimators/correa.jl
+++ b/test/entropies/estimators/correa.jl
@@ -19,3 +19,7 @@ ea_n3 = entropy(Shannon(; base = 3), Correa(m = 100), randn(npts))
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), Correa(), x)
+
+# Default is Shannon base-2 differential entropy
+est = Correa()
+@test entropy(est, x) == entropy(Shannon(; base = 2), est, x)

--- a/test/entropies/estimators/correa.jl
+++ b/test/entropies/estimators/correa.jl
@@ -7,12 +7,11 @@ U = 0.00
 # Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
 
-ec = Correa(m = 100, base = 2)
-ec_n = Correa(m = 100, base = MathConstants.e)
-
-n = 1000000
-@test round(entropy(ec, rand(rng, n)), digits = 2) == U
-@test round(entropy(ec_n, randn(rng, n)), digits = 2) == N
+npts = 1000000
+ea = entropy(Shannon(; base = 2), Correa(m = 100), rand(npts))
+ea_n = entropy(Shannon(; base = ℯ), Correa(m = 100), randn(npts))
+@test round(ea, digits = 2) == U
+@test round(ea_n, digits = 2) == N
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), Correa(), x)

--- a/test/entropies/estimators/correa.jl
+++ b/test/entropies/estimators/correa.jl
@@ -6,12 +6,16 @@
 U = 0.00
 # Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
+N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
 
 npts = 1000000
 ea = entropy(Shannon(; base = 2), Correa(m = 100), rand(npts))
 ea_n = entropy(Shannon(; base = ℯ), Correa(m = 100), randn(npts))
+ea_n3 = entropy(Shannon(; base = 3), Correa(m = 100), randn(npts))
+
 @test round(ea, digits = 2) == U
 @test round(ea_n, digits = 2) == N
+@test round(ea_n3, digits = 2) == N_base3
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), Correa(), x)

--- a/test/entropies/estimators/ebrahimi.jl
+++ b/test/entropies/estimators/ebrahimi.jl
@@ -19,3 +19,7 @@ ea_n3 = entropy(Shannon(; base = 3), Ebrahimi(m = 100), randn(npts))
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), Ebrahimi(), x)
+
+# Default is Shannon base-2 differential entropy
+est = Ebrahimi()
+@test entropy(est, x) == entropy(Shannon(; base = 2), est, x)

--- a/test/entropies/estimators/ebrahimi.jl
+++ b/test/entropies/estimators/ebrahimi.jl
@@ -6,14 +6,16 @@
 U = 0.00
 # Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
+N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
 
-ee = Ebrahimi(m = 100, base = 2)
-ee_n = Ebrahimi(m = 100, base = MathConstants.e)
+npts = 1000000
+ea = entropy(Shannon(; base = 2), Ebrahimi(m = 100), rand(npts))
+ea_n = entropy(Shannon(; base = ℯ), Ebrahimi(m = 100), randn(npts))
+ea_n3 = entropy(Shannon(; base = 3), Ebrahimi(m = 100), randn(npts))
 
-n = 1000000
-@test round(entropy(ee, rand(rng, n)), digits = 2) == U
-@test round(entropy(ee_n, randn(rng, n)), digits = 2) == N
-
+@test round(ea, digits = 2) == U
+@test round(ea_n, digits = 2) == N
+@test round(ea_n3, digits = 2) == N_base3
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), Ebrahimi(), x)

--- a/test/entropies/estimators/kozachenkoleonenko.jl
+++ b/test/entropies/estimators/kozachenkoleonenko.jl
@@ -19,3 +19,7 @@ ea_n3 = entropy(Shannon(; base = 3), KozachenkoLeonenko(), randn(npts))
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), KozachenkoLeonenko(), x)
+
+# Default is Shannon base-2 differential entropy
+est = KozachenkoLeonenko()
+@test entropy(est, x) == entropy(Shannon(; base = 2), est, x)

--- a/test/entropies/estimators/kozachenkoleonenko.jl
+++ b/test/entropies/estimators/kozachenkoleonenko.jl
@@ -1,28 +1,21 @@
-using DelayEmbeddings: genembed
-using DelayEmbeddings: Dataset
+# -------------------------------------------------------------------------------------
+# Check if the estimator converge to true values for some distributions with
+# analytically derivable entropy.
+# -------------------------------------------------------------------------------------
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+U = 0.00
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+N = round(0.5*log(2π) + 0.5, digits = 2)
+N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
 
-m = 4
-τ = 1
-τs = tuple([τ*i for i = 0:m-1]...)
-x = rand(250)
-D = genembed(x, τs)
-est = KozachenkoLeonenko(w = 1)
+npts = 1000000
+ea = entropy(Shannon(; base = 2), KozachenkoLeonenko(), rand(npts))
+ea_n = entropy(Shannon(; base = ℯ), KozachenkoLeonenko(), randn(npts))
+ea_n3 = entropy(Shannon(; base = 3), KozachenkoLeonenko(), randn(npts))
 
-@test entropy(est, D) isa Real
+@test round(ea, digits = 2) == U
+@test round(ea_n, digits = 2) == N
+@test round(ea_n3, digits = 2) == N_base3
 
-# Analytical test.
-XN = Dataset(randn(100000, 1));
-# For normal distribution with mean 0 and std 1, the entropy is
-h_XN_base_e = 0.5 * log(MathConstants.e, 2π) + 0.5 # nats
-h_XN_base_2 = h_XN_base_e / log(2, MathConstants.e) # bits
-
-h_XN_kr_base_e = entropy(KozachenkoLeonenko(base = MathConstants.e), XN)
-h_XN_kr_base_2 = entropy(KozachenkoLeonenko(base = 2), XN)
-# The KozachenkoLeonenko estimator is not as precise as Kraskov, so check that we're
-# within +- 3% of the target value
-tol_e = h_XN_base_e * 0.03
-tol_2 = h_XN_base_2 * 0.03
-@test h_XN_base_e - tol_e ≤ h_XN_kr_base_e ≤ h_XN_base_e + tol_e
-@test h_XN_base_2 - tol_2 ≤ h_XN_kr_base_2 ≤ h_XN_base_2 + tol_2
-
-@test_throws ArgumentError entropy(Renyi(q = 2), KozachenkoLeonenko(), XN)
+x = rand(1000)
+@test_throws ArgumentError entropy(Renyi(q = 2), KozachenkoLeonenko(), x)

--- a/test/entropies/estimators/kraskov.jl
+++ b/test/entropies/estimators/kraskov.jl
@@ -19,3 +19,7 @@ ea_n3 = entropy(Shannon(; base = 3), Kraskov(k = 5), randn(npts))
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), Kraskov(), x)
+
+# Default is Shannon base-2 differential entropy
+est = Kraskov()
+@test entropy(est, x) == entropy(Shannon(; base = 2), est, x)

--- a/test/entropies/estimators/kraskov.jl
+++ b/test/entropies/estimators/kraskov.jl
@@ -1,29 +1,21 @@
-using DelayEmbeddings: genembed
-using DelayEmbeddings: Dataset
+# -------------------------------------------------------------------------------------
+# Check if the estimator converge to true values for some distributions with
+# analytically derivable entropy.
+# -------------------------------------------------------------------------------------
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+U = 0.00
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+N = round(0.5*log(2π) + 0.5, digits = 2)
+N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
 
-m = 4
-τ = 1
-τs = tuple([τ*i for i = 0:m-1]...)
-x = rand(250)
-D = genembed(x, τs)
-est = Kraskov(k = 3, w = 1)
-e = Shannon()
-er = Renyi(q = 1.5)
-@test_throws ArgumentError entropy(er, est, D)
+npts = 1000000
+ea = entropy(Shannon(; base = 2), Kraskov(k = 5), rand(npts))
+ea_n = entropy(Shannon(; base = ℯ), Kraskov(k = 5), randn(npts))
+ea_n3 = entropy(Shannon(; base = 3), Kraskov(k = 5), randn(npts))
 
+@test round(ea, digits = 2) == U
+@test round(ea_n, digits = 2) == N
+@test round(ea_n3, digits = 2) == N_base3
 
-@test entropy(est, D) isa Real
-@test entropy(e, est, D) isa Real
-
-# Analytical test.
-XN = Dataset(randn(100000, 1));
-# For normal distribution with mean 0 and std 1, the entropy is
-h_XN_base_e = 0.5 * log(MathConstants.e, 2π) + 0.5 # nats
-h_XN_base_2 = h_XN_base_e / log(2, MathConstants.e) # bits
-
-h_XN_kr_base_e = entropy(Kraskov(k = 3, base = MathConstants.e), XN)
-h_XN_kr_base_2 = entropy(Kraskov(k = 3, base = 2), XN)
-@test round(h_XN_base_e, digits = 1) == round(h_XN_kr_base_e, digits = 1)
-@test round(h_XN_base_2, digits = 1) == round(h_XN_kr_base_2, digits = 1)
-
-@test_throws ArgumentError entropy(Renyi(q = 2), Kraskov(), XN)
+x = rand(1000)
+@test_throws ArgumentError entropy(Renyi(q = 2), Kraskov(), x)

--- a/test/entropies/estimators/vasicek.jl
+++ b/test/entropies/estimators/vasicek.jl
@@ -1,4 +1,3 @@
-
 # -------------------------------------------------------------------------------------
 # Check if the estimator converge to true values for some distributions with
 # analytically derivable entropy.
@@ -8,12 +7,11 @@ U = 0.00
 # Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
 
-ev = Vasicek(m = 100, base = 2)
-ev_n = Vasicek(m = 100, base = MathConstants.e)
-
-n = 1000000
-@test round(entropy(ev, rand(rng, n)), digits = 2) == U
-@test round(entropy(ev_n, randn(rng, n)), digits = 2) == N
+npts = 1000000
+ea = entropy(Shannon(; base = 2), Vasicek(m = 100), rand(npts))
+ea_n = entropy(Shannon(; base = ℯ), Vasicek(m = 100), randn(npts))
+@test round(ea, digits = 2) == U
+@test round(ea_n, digits = 2) == N
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), Vasicek(), x)

--- a/test/entropies/estimators/vasicek.jl
+++ b/test/entropies/estimators/vasicek.jl
@@ -6,12 +6,16 @@
 U = 0.00
 # Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
 N = round(0.5*log(2π) + 0.5, digits = 2)
+N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
+N_base2 = round((0.5*log(2π) + 0.5) / log(2, ℯ), digits = 2) # custom base
 
 npts = 1000000
 ea = entropy(Shannon(; base = 2), Vasicek(m = 100), rand(npts))
 ea_n = entropy(Shannon(; base = ℯ), Vasicek(m = 100), randn(npts))
+ea_n3 = entropy(Shannon(; base = 3), Vasicek(m = 100), randn(npts))
 @test round(ea, digits = 2) == U
 @test round(ea_n, digits = 2) == N
+@test round(ea_n3, digits = 2) == N_base3
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), Vasicek(), x)

--- a/test/entropies/estimators/vasicek.jl
+++ b/test/entropies/estimators/vasicek.jl
@@ -19,3 +19,7 @@ ea_n3 = entropy(Shannon(; base = 3), Vasicek(m = 100), randn(npts))
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), Vasicek(), x)
+
+# Default is Shannon base-2 differential entropy
+est = Vasicek()
+@test entropy(est, x) == entropy(Shannon(; base = 2), est, x)

--- a/test/entropies/estimators/zhu.jl
+++ b/test/entropies/estimators/zhu.jl
@@ -2,23 +2,29 @@ using DelayEmbeddings: Dataset
 
 # To ensure minimal rectangle volumes are correct, we also test internals directly here.
 # It's not feasible to construct an end-product test due to the neighbor searches.
-x = Dataset([[-1, -2], [0, -2], [3, 2]])
-y = Dataset([[3, 1], [-5, 1], [3, -2]])
+x = Dataset([[-1, -2], [0, -2], [3, 2]]);
+y = Dataset([[3, 1], [-5, 1], [3, -2]]);
 @test Entropies.volume_minimal_rect([0, 0], x) == 24
 @test Entropies.volume_minimal_rect([0, 0], y) == 40
 
-# Analytical tests for the estimated entropy
-DN = Dataset(randn(200000, 1))
-hN_base_e = 0.5 * log(MathConstants.e, 2π) + 0.5
-hN_base_2 = hN_base_e / log(2, MathConstants.e)
+# -------------------------------------------------------------------------------------
+# Check if the estimator converge to true values for some distributions with
+# analytically derivable entropy.
+# -------------------------------------------------------------------------------------
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+U = 0.00
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+N = round(0.5*log(2π) + 0.5, digits = 2)
+N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
 
-est = Zhu(k = 3)
+npts = 1000000
+ea = entropy(Shannon(; base = 2), Zhu(k = 5), rand(npts))
+ea_n = entropy(Shannon(; base = ℯ), Zhu(k = 5), randn(npts))
+ea_n3 = entropy(Shannon(; base = 3), Zhu(k = 5), randn(npts))
 
-@test round(entropy(Shannon(; base = ℯ), est, DN), digits = 1) == round(hN_base_e, digits = 1)
-@test round(entropy(Shannon(; base = 2), est, DN), digits = 1) == round(hN_base_2, digits = 1)
+@test round(ea, digits = 2) == U
+@test round(ea_n, digits = 2) == N
+@test round(ea_n3, digits = 2) == N_base3
 
-@test_throws ArgumentError entropy(Renyi(q = 2), Zhu(), DN)
-
-# Shannon entropy is default.
-@test entropy(Shannon(; base = 2), est, DN) ==  entropy(est, DN, base = 2)
-@test entropy(Shannon(; base = ℯ), est, DN) ==  entropy(est, DN, base = ℯ)
+x = rand(1000)
+@test_throws ArgumentError entropy(Renyi(q = 2), Zhu(k = 5), x)

--- a/test/entropies/estimators/zhu.jl
+++ b/test/entropies/estimators/zhu.jl
@@ -28,3 +28,7 @@ ea_n3 = entropy(Shannon(; base = 3), Zhu(k = 5), randn(npts))
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), Zhu(k = 5), x)
+
+# Default is Shannon base-2 differential entropy
+est = Zhu()
+@test entropy(est, x) == entropy(Shannon(; base = 2), est, x)

--- a/test/entropies/estimators/zhusingh.jl
+++ b/test/entropies/estimators/zhusingh.jl
@@ -28,40 +28,33 @@ vol = Entropies.volume_minimal_rect(dists)
 ξ = Entropies.n_borderpoints(x, nns, dists)
 @test vol == 40.0
 @test ξ == 1.0
+using DelayEmbeddings: Dataset
 
-# Analytical tests: 1D normal distribution
-DN = Dataset(randn(100000, 1))
-σ = 1.0
-hN_base_e = 0.5 * log(MathConstants.e, 2π * σ^2) + 0.5
-hN_base_2 = hN_base_e / log(2, MathConstants.e)
+# To ensure minimal rectangle volumes are correct, we also test internals directly here.
+# It's not feasible to construct an end-product test due to the neighbor searches.
+x = Dataset([[-1, -2], [0, -2], [3, 2]]);
+y = Dataset([[3, 1], [-5, 1], [3, -2]]);
+@test Entropies.volume_minimal_rect([0, 0], x) == 24
+@test Entropies.volume_minimal_rect([0, 0], y) == 40
 
-est = ZhuSingh(k = 3)
+# -------------------------------------------------------------------------------------
+# Check if the estimator converge to true values for some distributions with
+# analytically derivable entropy.
+# -------------------------------------------------------------------------------------
+# Entropy to log with base b of a uniform distribution on [0, 1] = ln(1 - 0)/(ln(b)) = 0
+U = 0.00
+# Entropy with natural log of 𝒩(0, 1) is 0.5*ln(2π) + 0.5.
+N = round(0.5*log(2π) + 0.5, digits = 2)
+N_base3 = round((0.5*log(2π) + 0.5) / log(3, ℯ), digits = 2) # custom base
 
-@test round(entropy(est, DN, base = ℯ), digits = 1) == round(hN_base_e, digits = 1)
-@test round(entropy(est, DN, base = 2), digits = 1) == round(hN_base_2, digits = 1)
+npts = 1000000
+ea = entropy(Shannon(; base = 2), Zhu(k = 5), rand(npts))
+ea_n = entropy(Shannon(; base = ℯ), Zhu(k = 5), randn(npts))
+ea_n3 = entropy(Shannon(; base = 3), Zhu(k = 5), randn(npts))
 
-# Analytical test: 3D normal distribution
-σs = ones(3)
-μs = zeros(3)
-𝒩₂ = MvNormal(μs, Diagonal(σs))
-Σ = diagm(σs)
-n = length(μs)
-h_𝒩₂_base_ℯ = 0.5n * log(ℯ, 2π) + 0.5*log(ℯ, det(Σ)) + 0.5n
-h_𝒩₂_base_2 = h_𝒩₂_base_ℯ  / log(2, ℯ)
+@test round(ea, digits = 2) == U
+@test round(ea_n, digits = 2) == N
+@test round(ea_n3, digits = 2) == N_base3
 
-sample = Dataset(transpose(rand(𝒩₂, 50000)))
-hZS_𝒩₂_base_ℯ = entropy(Shannon(; base = ℯ), est, sample)
-hZS_𝒩₂_base_2 = entropy(Shannon(; base = 2), est, sample)
-
-# Estimation accuracy decreases for fixed N with increasing edimension, so exact comparison
-# isn't useful. Just check that values are within 1% of the target.
-tol_ℯ  = hZS_𝒩₂_base_ℯ * 0.01
-tol_2  = hZS_𝒩₂_base_2 * 0.01
-@test h_𝒩₂_base_ℯ - tol_ℯ ≤ hZS_𝒩₂_base_ℯ ≤ h_𝒩₂_base_ℯ + tol_ℯ
-@test h_𝒩₂_base_2 - tol_2 ≤ hZS_𝒩₂_base_2 ≤ h_𝒩₂_base_2 + tol_2
-
-@test_throws ArgumentError entropy(Renyi(q = 2), ZhuSingh(), rand(100))
-
-# Shannon entropy is default.
-@test entropy(Shannon(; base = 2), est, sample) ==  entropy(est, sample, base = 2)
-@test entropy(Shannon(; base = ℯ), est, sample) ==  entropy(est, sample, base = ℯ)
+x = rand(1000)
+@test_throws ArgumentError entropy(Renyi(q = 2), Zhu(k = 5), x)

--- a/test/entropies/estimators/zhusingh.jl
+++ b/test/entropies/estimators/zhusingh.jl
@@ -58,3 +58,7 @@ ea_n3 = entropy(Shannon(; base = 3), Zhu(k = 5), randn(npts))
 
 x = rand(1000)
 @test_throws ArgumentError entropy(Renyi(q = 2), Zhu(k = 5), x)
+
+# Default is Shannon base-2 differential entropy
+est = ZhuSingh()
+@test entropy(est, x) == entropy(Shannon(; base = 2), est, x)


### PR DESCRIPTION
Improvements:
- Use `Shannon(; base = 2)` as default for both discrete and differential entropy.
- *Document* that the default base is 2 and instruct the user to provide an `Entropy` instance if they want to specify the logarithm.
- Add small example for differential entropy in docstring for `entropy`.
- Conform to `Entropy` API: `base` is given to the `Entropy`, not the `EntropyEstimator`.
- All `EntropyEstimator` docstrings now explicitly explain what they compute (ref #209).
- Tests for all subtypes of `EntropyEstimator` re-done and standardized (ref #209).

Bug fix
- Fixed scaling issue for order statistic estimators (use natural log in formulas, only scale *after* the entropy has been computed). Thus, tests also can be much stricter, because they are not biased by erroneous scaling.