### PR TITLE
Powerspectrum estimator add threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changelog is kept with respect to version 0.11 of Entropies.jl. From version v2.0 onwards, this package has been renamed to ComplexityMeasures.jl.
 
+## 3.9.5
+
+- Adding a new feature to `PowerSpectrum` estimator that adds a threshold for "small" amplitudes.
+
 ## 3.7.4
 
 - Critical performance fix: central type `Probabilities` was type unstable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog is kept with respect to version 0.11 of Entropies.jl. From version v2.0 onwards, this package has been renamed to ComplexityMeasures.jl.
 
-## 3.9.5
+## 3.9
 
 - Adding a new feature to `PowerSpectrum` estimator that adds a threshold for "small" amplitudes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog is kept with respect to version 0.11 of Entropies.jl. From version v2.
 
 ## 3.9
 
-- Adding a new feature to `PowerSpectrum` estimator that adds a threshold for "small" amplitudes.
+- Adding a new feature to `PowerSpectrum` estimator that adds a threshold for "small" amplitudes. The threshold is applied to the probabilities by default with an option to apply it to the power spectrum.
 
 ## 3.7.4
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.8.5"
+version = "3.9.5"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ComplexityMeasures"
 uuid = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 authors = "Kristian Agasøster Haaga <kahaaga@gmail.com>, George Datseries <datseris.george@gmail.com>"
 repo = "https://github.com/juliadynamics/ComplexityMeasures.jl.git"
-version = "3.9.5"
+version = "3.9.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -520,6 +520,12 @@ for N in (N1, N2)
         local h = information(PowerSpectrum(), q)
         local n = information_normalized(PowerSpectrum(), q)
         println("entropy: $(h), normalized: $(n).")
+        local h_thresh = information(PowerSpectrum(δ = 0.1), q)
+        local n_thresh = inforation_normalized(PowerSpectrum(δ = 0.1), q)
+        println("with a threshold; entropy: $(h_thresh), normalized: $(n_thresh).")
+        local h_thresh = information(PowerSpectrum(10.1, true), q)
+        local n_thresh = inforation_normalized(PowerSpectrum(10.1, true), q)
+        println("with threshold applied to power spectrum; entropy: $(h_thresh), normalized: $(n_thresh).")
     end
 end
 ```

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -521,10 +521,10 @@ for N in (N1, N2)
         local n = information_normalized(PowerSpectrum(), q)
         println("entropy: $(h), normalized: $(n).")
         local h_thresh = information(PowerSpectrum(δ = 0.1), q)
-        local n_thresh = inforation_normalized(PowerSpectrum(δ = 0.1), q)
+        local n_thresh = information_normalized(PowerSpectrum(δ = 0.1), q)
         println("with a threshold; entropy: $(h_thresh), normalized: $(n_thresh).")
         local h_thresh = information(PowerSpectrum(10.1, true), q)
-        local n_thresh = inforation_normalized(PowerSpectrum(10.1, true), q)
+        local n_thresh = information_normalized(PowerSpectrum(10.1, true), q)
         println("with threshold applied to power spectrum; entropy: $(h_thresh), normalized: $(n_thresh).")
     end
 end

--- a/src/outcome_spaces/power_spectrum.jl
+++ b/src/outcome_spaces/power_spectrum.jl
@@ -2,7 +2,7 @@ export PowerSpectrum
 import FFTW
 
 """
-    PowerSpectrum(δ = 5.0) <: OutcomeSpace
+    PowerSpectrum(δ = 0.0) <: OutcomeSpace
 
 An [`OutcomeSpace`](@ref) based on the power spectrum of a timeseries (amplitude square of
 its Fourier transform). There is an optional threshold, δ, that can be used to set amplitude
@@ -26,7 +26,7 @@ Input `x` is needed for a well-defined [`outcome_space`](@ref).
 struct PowerSpectrum{T<:Real} <: OutcomeSpace
     δ::T
 
-    function PowerSpectrum(δ::T = 5.0) where {T}
+    function PowerSpectrum(δ::T = 0.0) where {T}
         new{T}(δ)
     end
 end
@@ -37,9 +37,9 @@ function probabilities_and_outcomes(P::PowerSpectrum, x)
     end
     δ = getfield.(Ref(P), (:δ))
     f = FFTW.rfft(x)
-    y = abs2.(f)
-    y[0.0 < y < δ] = 0.0
-    probs = Probabilities(y)
+    amp_squared = abs2.(f)
+    amp_squared[0.0 .< amp_squared  .< δ] .= 0.0
+    probs = Probabilities(amp_squared)
     outs = FFTW.rfftfreq(length(x))
     p = Probabilities(probs, outs)
     return p, outcomes(p)

--- a/src/outcome_spaces/power_spectrum.jl
+++ b/src/outcome_spaces/power_spectrum.jl
@@ -2,10 +2,11 @@ export PowerSpectrum
 import FFTW
 
 """
-    PowerSpectrum() <: OutcomeSpace
+    PowerSpectrum(δ = 5.0) <: OutcomeSpace
 
 An [`OutcomeSpace`](@ref) based on the power spectrum of a timeseries (amplitude square of
-its Fourier transform).
+its Fourier transform). There is an optional threshold, δ, that can be used to set amplitude
+square of the timeseries' Fourier transform below δ's value to zero.
 
 If used with [`probabilities`](@ref), then the spectrum normalized to sum = 1
 is returned as probabilities.
@@ -22,14 +23,23 @@ The outcome space `Ω` for `PowerSpectrum` is the set of frequencies in Fourier 
 should be multiplied with the sampling rate of the signal, which is assumed to be `1`.
 Input `x` is needed for a well-defined [`outcome_space`](@ref).
 """
-struct PowerSpectrum <: OutcomeSpace end
+struct PowerSpectrum{T<:Real} <: OutcomeSpace
+    δ::T
 
-function probabilities_and_outcomes(::PowerSpectrum, x)
+    function PowerSpectrum(δ::T = 5.0) where {T}
+        new{T}(δ)
+    end
+end
+
+function probabilities_and_outcomes(P::PowerSpectrum, x)
     if !(x isa AbstractVector{<:Real})
         throw(ArgumentError("`PowerSpectrum` only works for timeseries input!"))
     end
+    δ = getfield.(Ref(P), (:δ))
     f = FFTW.rfft(x)
-    probs = Probabilities(abs2.(f))
+    y = abs2.(f)
+    y[0.0 < y < δ] = 0.0
+    probs = Probabilities(y)
     outs = FFTW.rfftfreq(length(x))
     p = Probabilities(probs, outs)
     return p, outcomes(p)

--- a/src/outcome_spaces/power_spectrum.jl
+++ b/src/outcome_spaces/power_spectrum.jl
@@ -23,9 +23,9 @@ The outcome space `Ω` for `PowerSpectrum` is the set of frequencies in Fourier 
 should be multiplied with the sampling rate of the signal, which is assumed to be `1`.
 Input `x` is needed for a well-defined [`outcome_space`](@ref).
 """
-@kwdef struct PowerSpectrum{T<:Real, X<:Bool} <: OutcomeSpace
+@kwdef struct PowerSpectrum{T<:Real} <: OutcomeSpace
     δ::T = 0.0
-    apply_threshold_to_spectrum::X = false
+    apply_threshold_to_spectrum::Bool = false
 end
 
 function probabilities_and_outcomes(P::PowerSpectrum, x)
@@ -41,7 +41,9 @@ function probabilities_and_outcomes(P::PowerSpectrum, x)
     outs = FFTW.rfftfreq(length(x))
     p = Probabilities(probs, outs)
     if P.δ > 0 && !P.apply_threshold_to_spectrum
-        p = Probabilities([x >= P.δ ? x : 0.0 for x in p], outs)
+        probs = [x >= P.δ ? x : 0.0 for x in p]
+        @assert !all(probs .== 0) "Threshold is too high! δ = $(P.δ); max probability = $(maximum(p))"
+        p = Probabilities(probs, outs)
     end
     return p, outcomes(p)
 end

--- a/src/outcome_spaces/power_spectrum.jl
+++ b/src/outcome_spaces/power_spectrum.jl
@@ -37,7 +37,9 @@ function probabilities_and_outcomes(P::PowerSpectrum, x)
     end
     f = FFTW.rfft(x)
     amp_squared = abs2.(f)
-    amp_squared[0.0 .< amp_squared  .< δ] .= 0.0
+    if P.δ > 0
+        amp_squared[amp_squared  .< P.δ] .= 0.0
+    end
     probs = Probabilities(amp_squared)
     outs = FFTW.rfftfreq(length(x))
     p = Probabilities(probs, outs)

--- a/src/outcome_spaces/power_spectrum.jl
+++ b/src/outcome_spaces/power_spectrum.jl
@@ -22,12 +22,8 @@ The outcome space `Ω` for `PowerSpectrum` is the set of frequencies in Fourier 
 should be multiplied with the sampling rate of the signal, which is assumed to be `1`.
 Input `x` is needed for a well-defined [`outcome_space`](@ref).
 """
-struct PowerSpectrum{T<:Real} <: OutcomeSpace
-    δ::T
-
-    function PowerSpectrum(δ::T = 0.0) where {T}
-        new{T}(δ)
-    end
+@kwdef struct PowerSpectrum{T<:Real} <: OutcomeSpace
+    δ::T = 0.0
 end
 
 function probabilities_and_outcomes(P::PowerSpectrum, x)

--- a/src/outcome_spaces/power_spectrum.jl
+++ b/src/outcome_spaces/power_spectrum.jl
@@ -5,8 +5,7 @@ import FFTW
     PowerSpectrum(δ = 0.0) <: OutcomeSpace
 
 An [`OutcomeSpace`](@ref) based on the power spectrum of a timeseries (amplitude square of
-its Fourier transform). There is an optional threshold, δ, that can be used to set amplitude
-square of the timeseries' Fourier transform below δ's value to zero.
+its Fourier transform). The optional threshold `δ` sets amplitudes below `δ` to zero.
 
 If used with [`probabilities`](@ref), then the spectrum normalized to sum = 1
 is returned as probabilities.

--- a/src/outcome_spaces/power_spectrum.jl
+++ b/src/outcome_spaces/power_spectrum.jl
@@ -35,7 +35,6 @@ function probabilities_and_outcomes(P::PowerSpectrum, x)
     if !(x isa AbstractVector{<:Real})
         throw(ArgumentError("`PowerSpectrum` only works for timeseries input!"))
     end
-    δ = getfield.(Ref(P), (:δ))
     f = FFTW.rfft(x)
     amp_squared = abs2.(f)
     amp_squared[0.0 .< amp_squared  .< δ] .= 0.0

--- a/src/outcome_spaces/power_spectrum.jl
+++ b/src/outcome_spaces/power_spectrum.jl
@@ -5,8 +5,8 @@ import FFTW
     PowerSpectrum(δ = 0.0, apply_threshold_to_spectrum = false) <: OutcomeSpace
 
 An [`OutcomeSpace`](@ref) based on the power spectrum of a timeseries (amplitude square of
-its Fourier transform). The optional threshold `δ` sets amplitudes below `δ` to zero.
-The optional `apply_threshold_to_spectrum` applies the threshold to the power spectrum if true.
+its Fourier transform). The optional threshold `δ` sets sum-normalized spectrum below `δ` to zero.
+The optional `apply_threshold_to_spectrum` applies the threshold directly to the power spectrum if `true`.
 
 If used with [`probabilities`](@ref), then the spectrum normalized to sum = 1
 is returned as probabilities.

--- a/src/outcome_spaces/power_spectrum.jl
+++ b/src/outcome_spaces/power_spectrum.jl
@@ -2,10 +2,11 @@ export PowerSpectrum
 import FFTW
 
 """
-    PowerSpectrum(δ = 0.0) <: OutcomeSpace
+    PowerSpectrum(δ = 0.0, apply_threshold_to_spectrum = false) <: OutcomeSpace
 
 An [`OutcomeSpace`](@ref) based on the power spectrum of a timeseries (amplitude square of
 its Fourier transform). The optional threshold `δ` sets amplitudes below `δ` to zero.
+The optional `apply_threshold_to_spectrum` applies the threshold to the power spectrum if true.
 
 If used with [`probabilities`](@ref), then the spectrum normalized to sum = 1
 is returned as probabilities.
@@ -22,8 +23,9 @@ The outcome space `Ω` for `PowerSpectrum` is the set of frequencies in Fourier 
 should be multiplied with the sampling rate of the signal, which is assumed to be `1`.
 Input `x` is needed for a well-defined [`outcome_space`](@ref).
 """
-@kwdef struct PowerSpectrum{T<:Real} <: OutcomeSpace
+@kwdef struct PowerSpectrum{T<:Real, X<:Bool} <: OutcomeSpace
     δ::T = 0.0
+    apply_threshold_to_spectrum::X = false
 end
 
 function probabilities_and_outcomes(P::PowerSpectrum, x)
@@ -32,12 +34,15 @@ function probabilities_and_outcomes(P::PowerSpectrum, x)
     end
     f = FFTW.rfft(x)
     amp_squared = abs2.(f)
-    if P.δ > 0
+    if P.δ > 0 && P.apply_threshold_to_spectrum
         amp_squared[amp_squared  .< P.δ] .= 0.0
     end
     probs = Probabilities(amp_squared)
     outs = FFTW.rfftfreq(length(x))
     p = Probabilities(probs, outs)
+    if P.δ > 0 && !P.apply_threshold_to_spectrum
+        p = Probabilities([x >= P.δ ? x : 0.0 for x in p], outs)
+    end
     return p, outcomes(p)
 end
 

--- a/test/outcome_spaces/implementations/timescales.jl
+++ b/test/outcome_spaces/implementations/timescales.jl
@@ -1,4 +1,6 @@
 using ComplexityMeasures, Test
+using Random
+rng = Random.MersenneTwister(1234)
 
 @testset "Timescales" begin
     N = 200
@@ -38,5 +40,19 @@ using ComplexityMeasures, Test
         @test probs[1] ≈ 0 atol=1e-16  # sine wave has 0 mean value
         @test outs[end] == 0.5 # Nyquist frequency, 1/2 the sampling rate (Which is 1)
         @test issorted(outcome_space(o, x))
+
+        x = cos.(range(0, 2π; length = 10000)) .+ 1e-2 .* randn(rng, 10000)
+        o = PowerSpectrum(δ = 0.1)
+        p, outs = probabilities_and_outcomes(o, x)
+        @test sum(p .> 0.0) == 1
+        @test length(outs) == length(p) == 5001
+        @test outs[1] ≈ 0 atol=1e-16
+        @test p[1] ≈ 0 atol=1e-16
+        o = PowerSpectrum(10.5, true)
+        p, ~ = probabilities_and_outcomes(o, x)
+        @test sum(p .> 0.0) == 1
+        @test length(outs) == length(p) == 5001
+        @test outs[1] ≈ 0 atol=1e-16
+        @test p[1] ≈ 0 atol=1e-16
     end
 end


### PR DESCRIPTION
Please review my change to add a threshold to the PowerSpectrum estimator. The optional threshold is named: $\delta$. I updated the docstring, and I was able to pass all the tests locally. However, I did not add any new tests, which is more challenging. For an example of how to use the new feature, please see the code below.
`
```julia
using DynamicalSystems, ComplexityMeasures

N1, N2, a = 101, 100001, 10

for N in (N1, N2)
    println("N: $(N)")
    t = LinRange(0, 2*a*π, N)
    x = sin.(t) # periodic
    y = sin.(t .+ cos.(t/0.5)) # periodic, complex spectrum
    z = sin.(rand(1:15, N) ./ rand(1:10, N)) # random
    w, t = trajectory(Systems.lorenz(), N÷10; Δt = 0.1, Ttr = 100) # chaotic
    w    = w[:, 1]

    for q in (x, y, z, w)
        p, ~ = probabilities_and_outcomes(PowerSpectrum(100.0), q)
        h = entropy(p)
        println("entropy: $(h).")
    end
end
````